### PR TITLE
WIP: Preliminary support for deCONZ Daylight sensor

### DIFF
--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -165,9 +165,9 @@ class Daylight(DeconzSensor):
         """Initialize daylight sensor."""
         self._daylight = device['state'].get('daylight')
         self._status = device['state'].get('status')
-        self._sensor_icon = 'mdi:white-balance-sunny'
         super().__init__(device_id, device)
         self._sensor_class = 'daylight'
+        self._sensor_icon = 'mdi:white-balance-sunny'
 
     @property
     def state(self):

--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -168,6 +168,7 @@ class Daylight(DeconzSensor):
         super().__init__(device_id, device)
         self._sensor_class = 'daylight'
         self._sensor_icon = 'mdi:white-balance-sunny'
+        self._reachable = True
 
     @property
     def state(self):
@@ -212,11 +213,6 @@ class Daylight(DeconzSensor):
     def daylight(self):
         """True if daylight, false if not."""
         return self._daylight
-
-    @property
-    def reachable(self):
-        """Always reachable, built into deCONZ."""
-        return True
 
 
 class Fire(DeconzSensor):

--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -163,7 +163,6 @@ class Daylight(DeconzSensor):
     def __init__(self, device_id, device):
         """Initialize daylight sensor."""
         self._daylight = device['state'].get('daylight')
-        self._reachable = True
         self._status = device['state'].get('status')
         super().__init__(device_id, device)
         self._sensor_class = 'daylight'
@@ -187,6 +186,11 @@ class Daylight(DeconzSensor):
     def status(self):
         """Daylight status."""
         return self._status
+
+    @property
+    def reachable(self):
+        """Always reachable, built into deCONZ."""
+        return True
 
 
 class Fire(DeconzSensor):

--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -20,8 +20,8 @@ SWITCH = ['ZHASwitch', 'ZGPSwitch', 'CLIPSwitch']
 TEMPERATURE = ['ZHATemperature', 'CLIPTemperature']
 WATER = ['ZHAWater']
 
-DECONZ_BINARY_SENSOR = DAYLIGHT + FIRE + OPENCLOSE + PRESENCE + WATER
-DECONZ_SENSOR = CONSUMPTION + GENERIC + HUMIDITY + LIGHTLEVEL + POWER + PRESSURE + TEMPERATURE + SWITCH
+DECONZ_BINARY_SENSOR = FIRE + OPENCLOSE + PRESENCE + WATER
+DECONZ_SENSOR = CONSUMPTION + DAYLIGHT + GENERIC + HUMIDITY + LIGHTLEVEL + POWER + PRESSURE + TEMPERATURE + SWITCH
 
 
 class DeconzSensor(DeconzDevice):
@@ -136,8 +136,9 @@ class Consumption(DeconzSensor):
 class Daylight(DeconzSensor):
     """Daylight sensor built into deCONZ software.
 
-    State parameter is a boolean named 'daylight'.
-    Also has a 'status' number.
+    State parameter is a string derived from 'status' parameter.
+    Strings from daylight.h at https://github.com/dresden-elektronik/deconz-rest-plugin.
+    Also has a 'daylight' boolean.
     Has no 'reachable' config parameter, so set sensor reachable True here.
     {
         "config": {
@@ -164,28 +165,53 @@ class Daylight(DeconzSensor):
         """Initialize daylight sensor."""
         self._daylight = device['state'].get('daylight')
         self._status = device['state'].get('status')
+        self._sensor_icon = 'mdi:white-balance-sunny'
         super().__init__(device_id, device)
         self._sensor_class = 'daylight'
 
     @property
     def state(self):
         """Main state of sensor."""
-        return self.is_tripped
-
-    @property
-    def is_tripped(self):
-        """Sensor is tripped."""
-        return self.daylight
-
-    @property
-    def daylight(self):
-        """If it's daylight or not."""
-        return self._daylight
+        return self.status
 
     @property
     def status(self):
-        """Daylight status."""
-        return self._status
+        """Return the daylight status string."""
+        if self._status == 100:
+            return "nadir"
+        elif self._status == 110:
+            return "night_end"
+        elif self._status == 120:
+            return "nautical_dawn"
+        elif self._status == 130:
+            return "dawn"
+        elif self._status == 140:
+            return "sunrise_start"
+        elif self._status == 150:
+            return "sunrise_end"
+        elif self._status == 160:
+            return "golden_hour_1"
+        elif self._status == 170:
+            return "solar_noon"
+        elif self._status == 180:
+            return "golden_hour_2"
+        elif self._status == 190:
+            return "sunset_start"
+        elif self._status == 200:
+            return "sunset_end"
+        elif self._status == 210:
+            return "dusk"
+        elif self._status == 220:
+            return "nautical_dusk"
+        elif self._status == 230:
+            return "night_start"
+        else:
+            return "unknown"
+
+    @property
+    def daylight(self):
+        """True if daylight, false if not."""
+        return self._daylight
 
     @property
     def reachable(self):

--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -134,10 +134,11 @@ class Consumption(DeconzSensor):
         return self._consumption
 
 class Daylight(DeconzSensor):
-    """Daylight sensor.
+    """Daylight sensor built into deCONZ software.
 
     State parameter is a boolean named 'daylight'.
-    Also has a "status" number.
+    Also has a 'status' number.
+    Has no 'reachable' config parameter, so set sensor reachable True here.
     {
         "config": {
             "configured": true,
@@ -162,6 +163,7 @@ class Daylight(DeconzSensor):
     def __init__(self, device_id, device):
         """Initialize daylight sensor."""
         self._daylight = device['state'].get('daylight')
+        self._reachable = True
         self._status = device['state'].get('status')
         super().__init__(device_id, device)
         self._sensor_class = 'daylight'


### PR DESCRIPTION
As of a recent version of deCONZ, there's now a Daylight sensor automatically created; I first noticed it when an error showed up in the HA logs. Anyway it could be useful to have in HA since I think the "status" property corresponds to the phase of daylight (the main property, "Daylight" is a boolean). 

I'm going to take a look at the Rest API repo or see if @manup can clarify what "status" corresponds to, since we could probably make that more useful here before it gets into HA (i.e. translate the status number to a useful string). 

Since this is built into deCONZ, it's always reachable and doesn't have a reachable config property, so I always return reachable as True.