### PR TITLE
Sync group colors from lights

### DIFF
--- a/pydeconz/group.py
+++ b/pydeconz/group.py
@@ -136,6 +136,21 @@ class DeconzGroup(DeconzLightBase):
             if scene['id'] not in self._scenes
         }
 
+    def update_color_state(self, light):
+        """Sync color state with light."""
+        x, y = light.xy
+        self.async_update({
+            'state': {
+                'bri': light.brightness,
+                'hue': light.hue,
+                'sat': light.sat,
+                'ct': light.ct,
+                'x': x,
+                'y': y,
+                'colormode': light.colormode,
+            },
+        })
+
 
 class DeconzScene:
     """deCONZ scene representation.


### PR DESCRIPTION
I've tested this and it works well with the latest version of HASS + lovelace UI. There are some occasional hiccups (delayed state updates in the UI) but based on websocket logs I think this is caused by delays from deCONZ.

I'm not familiar with the pydeconz API so please let me know if there's anything you'd like to see improved before accepting the pull request. There's some room for improvement in `sync_group_color` - currently all groups are updated every time a light changes color. This can be solved e.g. by maintaining a light->group dict and only updating the group a light belongs to, but I figured I'd hear your thoughts on the patch before working on this.

Fixes https://github.com/home-assistant/home-assistant/issues/20569
Refs https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1192