### PR TITLE
Set LightLevel sensor class to illuminance

### DIFF
--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -295,7 +295,7 @@ class LightLevel(DeconzSensor):
     BINARY = False
     ZHATYPE = ('ZHALightLevel', 'CLIPLightLevel')
 
-    SENSOR_CLASS = 'lux'
+    SENSOR_CLASS = 'illuminance'
     SENSOR_UNIT = 'lux'
 
     @property

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -331,7 +331,7 @@ async def test_lightlevel_sensor():
 
     assert sensor.BINARY is False
     assert sensor.ZHATYPE == ('ZHALightLevel', 'CLIPLightLevel')
-    assert sensor.SENSOR_CLASS == 'lux'
+    assert sensor.SENSOR_CLASS == 'illuminance'
     assert sensor.SENSOR_UNIT == 'lux'
 
     assert sensor.state == 5


### PR DESCRIPTION
Change class for LightLevel sensors to illuminance to match the appropriate hass device class.