### PR TITLE
Add support for test mode in (fire) sensor

### DIFF
--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -456,6 +456,11 @@ class Fire(DeconzBinarySensor):
         """Fire detected."""
         return self.raw["state"]["fire"]
 
+    @property
+    def test(self) -> Optional[bool]:
+        """Sensor is in test mode."""
+        return self.raw["state"].get("test")
+
 
 class GenericFlag(DeconzBinarySensor):
     """Generic flag sensor."""

--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -457,7 +457,7 @@ class Fire(DeconzBinarySensor):
         return self.raw["state"]["fire"]
 
     @property
-    def test(self) -> Optional[bool]:
+    def in_test_mode(self) -> Optional[bool]:
         """Sensor is in test mode."""
         return self.raw["state"].get("test")
 

--- a/pydeconz/sensor.py
+++ b/pydeconz/sensor.py
@@ -457,9 +457,9 @@ class Fire(DeconzBinarySensor):
         return self.raw["state"]["fire"]
 
     @property
-    def in_test_mode(self) -> Optional[bool]:
+    def in_test_mode(self) -> bool:
         """Sensor is in test mode."""
-        return self.raw["state"].get("test")
+        return self.raw["state"].get("test", False)
 
 
 class GenericFlag(DeconzBinarySensor):

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -560,6 +560,7 @@ async def test_fire_sensor():
     assert sensor.on is True
     assert sensor.reachable is True
     assert sensor.tampered is None
+    assert sensor.test is None
     assert sensor.secondary_temperature is None
 
     # DeconzDevice
@@ -571,6 +572,60 @@ async def test_fire_sensor():
     assert sensor.software_version == ""
     assert sensor.type == "ZHAFire"
     assert sensor.unique_id == "00:15:8d:00:01:d9:3e:7c-01-0500"
+
+
+async def test_fire_sensor_test_develco():
+    """Verify that develco/frient fire sensor works."""
+    sensors = Sensors(
+        {
+            "0": {
+                "config": {"on": True, "battery": 90, "reachable": True},
+                "ep": 1,
+                "etag": "abcdef1234567890abcdef1234567890",
+                "manufacturername": "frient A/S",
+                "modelid": "SMSZB-120",
+                "name": "Fire alarm",
+                "state": {
+                    "fire": False,
+                    "lastupdated": "2021-11-25T08:00:02.003",
+                    "lowbattery": False,
+                    "test": True
+                },
+                "swversion": "20210526 05:57",
+                "type": "ZHAFire",
+                "uniqueid": "00:11:22:33:44:55:66:77-88-9900"
+            }
+
+        },
+        AsyncMock(),
+    )
+    sensor = sensors["0"]
+
+    assert sensor.BINARY is True
+    assert sensor.ZHATYPE == ("ZHAFire",)
+
+    assert sensor.state is False
+    assert sensor.fire is False
+
+    # DeconzSensor
+    assert sensor.battery == 90
+    assert sensor.ep == 1
+    assert sensor.low_battery is False
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.test is True
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "abcdef1234567890abcdef1234567890"
+    assert sensor.manufacturer == "frient A/S"
+    assert sensor.model_id == "SMSZB-120"
+    assert sensor.name == "Fire alarm"
+    assert sensor.software_version == "20210526 05:57"
+    assert sensor.type == "ZHAFire"
+    assert sensor.unique_id == "00:11:22:33:44:55:66:77-88-9900"
 
 
 async def test_genericflag_sensor():

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -560,7 +560,7 @@ async def test_fire_sensor():
     assert sensor.on is True
     assert sensor.reachable is True
     assert sensor.tampered is None
-    assert sensor.test is None
+    assert sensor.in_test_mode is None
     assert sensor.secondary_temperature is None
 
     # DeconzDevice
@@ -614,7 +614,7 @@ async def test_fire_sensor_test_develco():
     assert sensor.on is True
     assert sensor.reachable is True
     assert sensor.tampered is None
-    assert sensor.test is True
+    assert sensor.in_test_mode is True
     assert sensor.secondary_temperature is None
 
     # DeconzDevice

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -560,7 +560,7 @@ async def test_fire_sensor():
     assert sensor.on is True
     assert sensor.reachable is True
     assert sensor.tampered is None
-    assert sensor.in_test_mode is None
+    assert sensor.in_test_mode is False
     assert sensor.secondary_temperature is None
 
     # DeconzDevice


### PR DESCRIPTION
This PR adds support for the test mode of fire/smoke sensors. The tests are created by mocking a Develco/Frient smoke alarm, model SMSZB-120.
The initial implementation of this PR was done by @madwizard-thomas in his PR https://github.com/Kane610/deconz/pull/188.

I took his PR as the base for my PR and

- renamed the test property to `in_test_mode`
- changed the method return type to be a strict bool
- set the default value of the test mode to be `False`.