### PR TITLE
Use request_with_retry when doing "put" to groups and scenes

### DIFF
--- a/pydeconz/interfaces/groups.py
+++ b/pydeconz/interfaces/groups.py
@@ -138,7 +138,7 @@ class Groups(APIItems[Group]):
             data["alert"] = alert.value
         if effect is not None:
             data["effect"] = effect.value
-        return await self.gateway.request(
+        return await self.gateway.request_with_retry(
             "put",
             path=f"{self.path}/{id}/action",
             json=data,

--- a/pydeconz/interfaces/scenes.py
+++ b/pydeconz/interfaces/scenes.py
@@ -36,7 +36,7 @@ class Scenes(APIItems[Scene]):
 
     async def recall(self, group_id: str, scene_id: str) -> dict[str, Any]:
         """Recall scene to group."""
-        return await self.gateway.request(
+        return await self.gateway.request_with_retry(
             "put",
             path=f"/groups/{group_id}/scenes/{scene_id}/recall",
             json={},
@@ -47,7 +47,7 @@ class Scenes(APIItems[Scene]):
 
         The actual state of each light in the group will become the lights scene state.
         """
-        return await self.gateway.request(
+        return await self.gateway.request_with_retry(
             "put",
             path=f"/groups/{group_id}/scenes/{scene_id}/store",
             json={},
@@ -68,7 +68,7 @@ class Scenes(APIItems[Scene]):
             }.items()
             if value is not None
         }
-        return await self.gateway.request(
+        return await self.gateway.request_with_retry(
             "put",
             path=f"/groups/{group_id}/scenes/{scene_id}",
             json=data,


### PR DESCRIPTION
> Smanar — Yesterday at 7:33 PM


```
rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/config/rfconnected"), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)))
rsp.list.append(errorToMap(ERR_INTERNAL_ERROR, QString("/groups/%1").arg(id), QString("Internal error, %1").arg(ERR_BRIDGE_BUSY)));
rsp.list.append(errorToMap(ERR_BRIDGE_BUSY, QString("/groups/%1/scenes/%2").arg(gid).arg(sid), QString("gateway busy")));
```