### PR TITLE
Support AirPurifier

### DIFF
--- a/pydeconz/models/__init__.py
+++ b/pydeconz/models/__init__.py
@@ -66,6 +66,9 @@ class ResourceType(Enum):
 
     # Sensor resources
 
+    # Air purifier
+    ZHA_AIR_PURIFIER = "ZHAAirPurifier"
+
     # Air quality
     ZHA_AIR_QUALITY = "ZHAAirQuality"
 

--- a/pydeconz/models/sensor/air_purifier.py
+++ b/pydeconz/models/sensor/air_purifier.py
@@ -4,23 +4,13 @@ import enum
 from typing import Literal, TypedDict
 
 from . import SensorBase
-from .air_quality import AirQualityValue
 
 
 class TypedAirPurifierState(TypedDict):
     """Air purifier state type definition."""
 
-    airquality: Literal[
-        "excellent",
-        "good",
-        "moderate",
-        "poor",
-        "unhealthy",
-        "out of scale",
-    ]
     deviceruntime: int
     filterruntime: int
-    pm2_5: int
     replacefilter: bool
     speed: int
 
@@ -71,11 +61,6 @@ class AirPurifier(SensorBase):
     raw: TypedAirPurifier
 
     @property
-    def air_quality(self) -> AirQualityValue:
-        """Air quality."""
-        return AirQualityValue(self.raw["state"]["airquality"])
-
-    @property
     def device_run_time(self) -> int:
         """Device run time in minutes."""
         return self.raw["state"]["deviceruntime"]
@@ -109,11 +94,6 @@ class AirPurifier(SensorBase):
     def locked(self) -> bool:
         """Locked configuration."""
         return self.raw["config"]["locked"]
-
-    @property
-    def pm_2_5(self) -> int:
-        """Air quality PM2.5 (µg/m³)."""
-        return self.raw["state"]["pm2_5"]
 
     @property
     def replace_filter(self) -> bool:

--- a/pydeconz/models/sensor/air_purifier.py
+++ b/pydeconz/models/sensor/air_purifier.py
@@ -1,0 +1,121 @@
+"""Air purifier data model."""
+
+import enum
+from typing import Literal, TypedDict
+
+from . import SensorBase
+from .air_quality import AirQualityValue
+
+
+class TypedAirPurifierState(TypedDict):
+    """Air purifier state type definition."""
+
+    airquality: Literal[
+        "excellent",
+        "good",
+        "moderate",
+        "poor",
+        "unhealthy",
+        "out of scale",
+    ]
+    deviceruntime: int
+    filterruntime: int
+    pm2_5: int
+    replacefilter: bool
+    speed: int
+
+
+class TypedAirPurifierConfig(TypedDict):
+    """Air purifier config type definition."""
+
+    filterlifetime: int
+    ledindication: bool
+    locked: bool
+    mode: Literal[
+        "off",
+        "auto",
+        "speed_1",
+        "speed_2",
+        "speed_3",
+        "speed_4",
+        "speed_5",
+    ]
+    on: bool
+    reachable: bool
+
+
+class TypedAirPurifier(TypedDict):
+    """Air purifier type definition."""
+
+    config: TypedAirPurifierConfig
+    state: TypedAirPurifierState
+
+
+class AirPurifierFanMode(enum.Enum):
+    """Air purifier supported fan modes."""
+
+    OFF = "off"
+    AUTO = "auto"
+    SPEED1 = "speed_1"
+    SPEED2 = "speed_2"
+    SPEED3 = "speed_3"
+    SPEED4 = "speed_4"
+    SPEED5 = "speed_5"
+
+
+class AirPurifier(SensorBase):
+    """Air purifier sensor."""
+
+    ZHATYPE = ("ZHAAirPurifier",)
+
+    raw: TypedAirPurifier
+
+    @property
+    def air_quality(self) -> AirQualityValue:
+        """Air quality."""
+        return AirQualityValue(self.raw["state"]["airquality"])
+
+    @property
+    def device_run_time(self) -> int:
+        """Device run time in minutes."""
+        return self.raw["state"]["deviceruntime"]
+
+    @property
+    def fan_mode(self) -> AirPurifierFanMode:
+        """Fan mode."""
+        return AirPurifierFanMode(self.raw["config"]["mode"])
+
+    @property
+    def fan_speed(self) -> int:
+        """Fan speed."""
+        return self.raw["state"]["speed"]
+
+    @property
+    def filter_life_time(self) -> int:
+        """Filter life time in minutes."""
+        return self.raw["config"]["filterlifetime"]
+
+    @property
+    def filter_run_time(self) -> int:
+        """Filter run time in minutes."""
+        return self.raw["state"]["filterruntime"]
+
+    @property
+    def led_indication(self) -> bool:
+        """Led indicator."""
+        return self.raw["config"]["ledindication"]
+
+    @property
+    def locked(self) -> bool:
+        """Locked configuration."""
+        return self.raw["config"]["locked"]
+
+    @property
+    def pm_2_5(self) -> int:
+        """Air quality PM2.5 (µg/m³)."""
+        return self.raw["state"]["pm2_5"]
+
+    @property
+    def replace_filter(self) -> bool:
+        """Replace filter property."""
+        return self.raw["state"]["replacefilter"]

--- a/pydeconz/models/sensor/air_quality.py
+++ b/pydeconz/models/sensor/air_quality.py
@@ -55,9 +55,9 @@ class AirQuality(SensorBase):
     raw: TypedAirQuality
 
     @property
-    def air_quality(self) -> AirQualityValue:
+    def air_quality(self) -> str:  # AirQualityValue:
         """Air quality."""
-        return AirQualityValue(self.raw["state"]["airquality"])
+        return AirQualityValue(self.raw["state"]["airquality"]).value
 
     @property
     def air_quality_ppb(self) -> int:

--- a/pydeconz/models/sensor/air_quality.py
+++ b/pydeconz/models/sensor/air_quality.py
@@ -1,8 +1,29 @@
 """Python library to connect deCONZ and Home Assistant to work together."""
 
+import enum
 from typing import Literal, TypedDict
 
 from . import SensorBase
+
+
+class AirQualityValue(enum.Enum):
+    """Air quality.
+
+    Supported values:
+    - "excellent"
+    - "good"
+    - "moderate"
+    - "poor"
+    - "unhealthy"
+    - "out of scale"
+    """
+
+    EXCELLENT = "excellent"
+    GOOD = "good"
+    MODERATE = "moderate"
+    POOR = "poor"
+    UNHEALTHY = "unhealthy"
+    OUT_OF_SCALE = "out of scale"
 
 
 class TypedAirQualityState(TypedDict):
@@ -33,22 +54,11 @@ class AirQuality(SensorBase):
     raw: TypedAirQuality
 
     @property
-    def air_quality(
-        self,
-    ) -> Literal["excellent", "good", "moderate", "poor", "unhealthy", "out of scale"]:
-        """Air quality.
-
-        Supported values:
-        - "excellent"
-        - "good"
-        - "moderate"
-        - "poor"
-        - "unhealthy"
-        - "out of scale"
-        """
-        return self.raw["state"]["airquality"]
+    def air_quality(self) -> AirQualityValue:
+        """Air quality."""
+        return AirQualityValue(self.raw["state"]["airquality"])
 
     @property
     def air_quality_ppb(self) -> int:
-        """Air quality PPB."""
+        """Air quality PPB TVOC."""
         return self.raw["state"]["airqualityppb"]

--- a/pydeconz/models/sensor/air_quality.py
+++ b/pydeconz/models/sensor/air_quality.py
@@ -6,6 +6,27 @@ from typing import Literal, TypedDict
 from . import SensorBase
 
 
+class TypedAirQualityState(TypedDict):
+    """Air quality state type definition."""
+
+    airquality: Literal[
+        "excellent",
+        "good",
+        "moderate",
+        "poor",
+        "unhealthy",
+        "out of scale",
+    ]
+    airqualityppb: int
+    pm2_5: int
+
+
+class TypedAirQuality(TypedDict):
+    """Air quality type definition."""
+
+    state: TypedAirQualityState
+
+
 class AirQualityValue(enum.Enum):
     """Air quality.
 
@@ -26,26 +47,6 @@ class AirQualityValue(enum.Enum):
     OUT_OF_SCALE = "out of scale"
 
 
-class TypedAirQualityState(TypedDict):
-    """Air quality state type definition."""
-
-    airquality: Literal[
-        "excellent",
-        "good",
-        "moderate",
-        "poor",
-        "unhealthy",
-        "out of scale",
-    ]
-    airqualityppb: int
-
-
-class TypedAirQuality(TypedDict):
-    """Air quality type definition."""
-
-    state: TypedAirQualityState
-
-
 class AirQuality(SensorBase):
     """Air quality sensor."""
 
@@ -62,3 +63,18 @@ class AirQuality(SensorBase):
     def air_quality_ppb(self) -> int:
         """Air quality PPB TVOC."""
         return self.raw["state"]["airqualityppb"]
+
+    @property
+    def pm_2_5(self) -> int:
+        """Air quality PM2.5 (µg/m³)."""
+        return self.raw["state"]["pm2_5"]
+
+    @property
+    def supports_air_quality_ppb(self) -> bool:
+        """Support Air quality PPB reporting."""
+        return "airqualityppb" in self.raw["state"]
+
+    @property
+    def supports_pm_2_5(self) -> bool:
+        """Support Air quality PM2.5 reporting."""
+        return "pm2_5" in self.raw["state"]

--- a/tests/sensors/test_air_purifier.py
+++ b/tests/sensors/test_air_purifier.py
@@ -1,0 +1,105 @@
+"""Test pydeCONZ air purifier.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.air_purifier tests/sensors/test_air_purifier.py
+"""
+
+from pydeconz.models.sensor.air_purifier import AirPurifierFanMode, AirQualityValue
+
+
+async def test_control_air_purifier(
+    mock_aioresponse, deconz_session, deconz_called_with
+):
+    """Verify that air purifier controls works."""
+    air_purifier = deconz_session.sensors.air_purifier
+
+    mock_aioresponse.put("http://host:80/api/apikey/sensors/0/config")
+    await air_purifier.set_config("0", AirPurifierFanMode.AUTO)
+    assert deconz_called_with("put", path="/sensors/0/config", json={"mode": "auto"})
+
+    mock_aioresponse.put("http://host:80/api/apikey/sensors/0/config")
+    await air_purifier.set_config("0", AirPurifierFanMode.OFF)
+    assert deconz_called_with("put", path="/sensors/0/config", json={"mode": "off"})
+
+    mock_aioresponse.put("http://host:80/api/apikey/sensors/0/config")
+    await air_purifier.set_config(
+        "0",
+        filter_life_time=1,
+        led_indication=True,
+        locked=False,
+    )
+    assert deconz_called_with(
+        "put",
+        path="/sensors/0/config",
+        json={
+            "filterlifetime": 1,
+            "ledindication": True,
+            "locked": False,
+        },
+    )
+
+
+async def test_air_purifier_sensor(deconz_sensor):
+    """Verify that air purifier sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {
+                "filterlifetime": 256728,
+                "ledindication": True,
+                "locked": False,
+                "mode": "auto",
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "c4b3b77e0fc9b62f7f6b85031de61d98",
+            "lastannounced": None,
+            "lastseen": "2022-06-11T15:40Z",
+            "manufacturername": "IKEA of Sweden",
+            "modelid": "STARKVIND Air purifier",
+            "name": "Starkvind",
+            "state": {
+                "airquality": "excellent",
+                "deviceruntime": 185310,
+                "filterruntime": 182857,
+                "lastupdated": "2022-06-11T15:39:46.328",
+                "pm2_5": 6,
+                "replacefilter": False,
+                "speed": 20,
+            },
+            "swversion": "1.0.033",
+            "type": "ZHAAirPurifier",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-fc7d",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAAirPurifier",)
+
+    assert sensor.air_quality == AirQualityValue.EXCELLENT
+    assert sensor.device_run_time == 185310
+    assert sensor.fan_mode == AirPurifierFanMode.AUTO
+    assert sensor.fan_speed == 20
+    assert sensor.filter_life_time == 256728
+    assert sensor.filter_run_time == 182857
+    assert sensor.led_indication is True
+    assert sensor.locked is False
+    assert sensor.pm_2_5 == 6
+    assert sensor.replace_filter is False
+
+    # DeconzSensor
+    assert sensor.battery is None
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "c4b3b77e0fc9b62f7f6b85031de61d98"
+    assert sensor.manufacturer == "IKEA of Sweden"
+    assert sensor.model_id == "STARKVIND Air purifier"
+    assert sensor.name == "Starkvind"
+    assert sensor.software_version == "1.0.033"
+    assert sensor.type == "ZHAAirPurifier"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-fc7d"

--- a/tests/sensors/test_air_purifier.py
+++ b/tests/sensors/test_air_purifier.py
@@ -3,7 +3,7 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.air_purifier tests/sensors/test_air_purifier.py
 """
 
-from pydeconz.models.sensor.air_purifier import AirPurifierFanMode, AirQualityValue
+from pydeconz.models.sensor.air_purifier import AirPurifierFanMode
 
 
 async def test_control_air_purifier(
@@ -51,18 +51,16 @@ async def test_air_purifier_sensor(deconz_sensor):
                 "reachable": True,
             },
             "ep": 1,
-            "etag": "c4b3b77e0fc9b62f7f6b85031de61d98",
+            "etag": "fea6623ea3909029409fed7a6224e60b",
             "lastannounced": None,
-            "lastseen": "2022-06-11T15:40Z",
+            "lastseen": "2022-06-30T18:19Z",
             "manufacturername": "IKEA of Sweden",
             "modelid": "STARKVIND Air purifier",
             "name": "Starkvind",
             "state": {
-                "airquality": "excellent",
                 "deviceruntime": 185310,
                 "filterruntime": 182857,
                 "lastupdated": "2022-06-11T15:39:46.328",
-                "pm2_5": 6,
                 "replacefilter": False,
                 "speed": 20,
             },
@@ -74,7 +72,6 @@ async def test_air_purifier_sensor(deconz_sensor):
 
     assert sensor.ZHATYPE == ("ZHAAirPurifier",)
 
-    assert sensor.air_quality == AirQualityValue.EXCELLENT
     assert sensor.device_run_time == 185310
     assert sensor.fan_mode == AirPurifierFanMode.AUTO
     assert sensor.fan_speed == 20
@@ -82,7 +79,6 @@ async def test_air_purifier_sensor(deconz_sensor):
     assert sensor.filter_run_time == 182857
     assert sensor.led_indication is True
     assert sensor.locked is False
-    assert sensor.pm_2_5 == 6
     assert sensor.replace_filter is False
 
     # DeconzSensor
@@ -96,7 +92,7 @@ async def test_air_purifier_sensor(deconz_sensor):
 
     # DeconzDevice
     assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "c4b3b77e0fc9b62f7f6b85031de61d98"
+    assert sensor.etag == "fea6623ea3909029409fed7a6224e60b"
     assert sensor.manufacturer == "IKEA of Sweden"
     assert sensor.model_id == "STARKVIND Air purifier"
     assert sensor.name == "Starkvind"

--- a/tests/sensors/test_air_quality.py
+++ b/tests/sensors/test_air_quality.py
@@ -30,7 +30,7 @@ async def test_air_quality_sensor(deconz_sensor):
 
     assert sensor.ZHATYPE == ("ZHAAirQuality",)
 
-    assert sensor.air_quality == AirQualityValue.POOR
+    assert sensor.air_quality == AirQualityValue.POOR.value
     assert sensor.supports_air_quality_ppb is True
     assert sensor.air_quality_ppb == 809
     assert sensor.supports_pm_2_5 is False
@@ -81,7 +81,7 @@ async def test_air_quality_sensor_with_pm2_5(deconz_sensor):
 
     assert sensor.ZHATYPE == ("ZHAAirQuality",)
 
-    assert sensor.air_quality == AirQualityValue.EXCELLENT
+    assert sensor.air_quality == AirQualityValue.EXCELLENT.value
     assert sensor.supports_air_quality_ppb is False
     assert sensor.supports_pm_2_5 is True
     assert sensor.pm_2_5 == 8

--- a/tests/sensors/test_air_quality.py
+++ b/tests/sensors/test_air_quality.py
@@ -1,0 +1,54 @@
+"""Test pydeCONZ air quality sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.air_quality tests/sensors/test_air_quality.py
+"""
+
+from pydeconz.models.sensor.air_quality import AirQualityValue
+
+
+async def test_air_quality_sensor(deconz_sensor):
+    """Verify that air quality sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"on": True, "reachable": True},
+            "ep": 2,
+            "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
+            "lastseen": "2020-11-20T22:48Z",
+            "manufacturername": "BOSCH",
+            "modelid": "AIR",
+            "name": "BOSCH Air quality sensor",
+            "state": {
+                "airquality": "poor",
+                "airqualityppb": 809,
+                "lastupdated": "2020-11-20T22:48:00.209",
+            },
+            "swversion": "20200402",
+            "type": "ZHAAirQuality",
+            "uniqueid": "00:12:4b:00:14:4d:00:07-02-fdef",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAAirQuality",)
+
+    assert sensor.air_quality == AirQualityValue.POOR
+    assert sensor.air_quality_ppb == 809
+
+    # DeconzSensor
+    assert sensor.battery is None
+    assert sensor.config_pending is None
+    assert sensor.ep == 2
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "c2d2e42396f7c78e11e46c66e2ec0200"
+    assert sensor.manufacturer == "BOSCH"
+    assert sensor.model_id == "AIR"
+    assert sensor.name == "BOSCH Air quality sensor"
+    assert sensor.software_version == "20200402"
+    assert sensor.type == "ZHAAirQuality"
+    assert sensor.unique_id == "00:12:4b:00:14:4d:00:07-02-fdef"

--- a/tests/sensors/test_air_quality.py
+++ b/tests/sensors/test_air_quality.py
@@ -31,7 +31,9 @@ async def test_air_quality_sensor(deconz_sensor):
     assert sensor.ZHATYPE == ("ZHAAirQuality",)
 
     assert sensor.air_quality == AirQualityValue.POOR
+    assert sensor.supports_air_quality_ppb is True
     assert sensor.air_quality_ppb == 809
+    assert sensor.supports_pm_2_5 is False
 
     # DeconzSensor
     assert sensor.battery is None
@@ -52,3 +54,34 @@ async def test_air_quality_sensor(deconz_sensor):
     assert sensor.software_version == "20200402"
     assert sensor.type == "ZHAAirQuality"
     assert sensor.unique_id == "00:12:4b:00:14:4d:00:07-02-fdef"
+
+
+async def test_air_quality_sensor_with_pm2_5(deconz_sensor):
+    """Verify that air quality with PM 2.5 sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"on": True, "reachable": True},
+            "ep": 1,
+            "etag": "74eb5d8558a3895a39a3884189701c99",
+            "lastannounced": None,
+            "lastseen": "2022-06-30T18:20Z",
+            "manufacturername": "IKEA of Sweden",
+            "modelid": "STARKVIND Air purifier",
+            "name": "Starkvind",
+            "state": {
+                "airquality": "excellent",
+                "lastupdated": "2022-06-30T18:18:26.205",
+                "pm2_5": 8,
+            },
+            "swversion": "1.0.033",
+            "type": "ZHAAirQuality",
+            "uniqueid": "cc:86:ec:ff:fe:6d:30:11-02-fc7d",
+        }
+    )
+
+    assert sensor.ZHATYPE == ("ZHAAirQuality",)
+
+    assert sensor.air_quality == AirQualityValue.EXCELLENT
+    assert sensor.supports_air_quality_ppb is False
+    assert sensor.supports_pm_2_5 is True
+    assert sensor.pm_2_5 == 8

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -81,7 +81,7 @@ async def test_initial_state(deconz_session, deconz_refresh_state, count_subscri
     assert count_subscribers() == 1  # Scene subscribed to groups
 
     unsub = deconz_session.subscribe(session_subscription := Mock())
-    assert count_subscribers() == 33
+    assert count_subscribers() == 34
 
     await deconz_refresh_state(
         alarm_systems={"0": {}},

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -20,54 +20,6 @@ def deconz_sensor(deconz_refresh_state):
     yield data_to_deconz_session
 
 
-async def test_air_quality_sensor(deconz_sensor):
-    """Verify that air quality sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "ep": 2,
-            "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
-            "lastseen": "2020-11-20T22:48Z",
-            "manufacturername": "BOSCH",
-            "modelid": "AIR",
-            "name": "BOSCH Air quality sensor",
-            "state": {
-                "airquality": "poor",
-                "airqualityppb": 809,
-                "lastupdated": "2020-11-20T22:48:00.209",
-            },
-            "swversion": "20200402",
-            "type": "ZHAAirQuality",
-            "uniqueid": "00:12:4b:00:14:4d:00:07-02-fdef",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHAAirQuality",)
-
-    assert sensor.air_quality == "poor"
-    assert sensor.air_quality_ppb == 809
-
-    # DeconzSensor
-    assert sensor.battery is None
-    assert sensor.config_pending is None
-    assert sensor.ep == 2
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "c2d2e42396f7c78e11e46c66e2ec0200"
-    assert sensor.manufacturer == "BOSCH"
-    assert sensor.model_id == "AIR"
-    assert sensor.name == "BOSCH Air quality sensor"
-    assert sensor.software_version == "20200402"
-    assert sensor.type == "ZHAAirQuality"
-    assert sensor.unique_id == "00:12:4b:00:14:4d:00:07-02-fdef"
-
-
 async def test_alarm_sensor(deconz_sensor):
     """Verify that alarm sensor works."""
     sensor = await deconz_sensor(


### PR DESCRIPTION
Based on https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6124

Prepare AirQuality to return an enum rather than a string

1. Add full implementation of Air purifier based on first draft with AirPurifier and AirQuality in same endpoint
2. Alter implementation to reflect second draft of AirPurifier and AirQuality as separate endpoints