### PR TITLE
Improve sensor test structure

### DIFF
--- a/pydeconz/models/sensor/air_purifier.py
+++ b/pydeconz/models/sensor/air_purifier.py
@@ -3,6 +3,8 @@
 import enum
 from typing import Literal, TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -56,7 +58,7 @@ class AirPurifierFanMode(enum.Enum):
 class AirPurifier(SensorBase):
     """Air purifier sensor."""
 
-    ZHATYPE = ("ZHAAirPurifier",)
+    ZHATYPE = (ResourceType.ZHA_AIR_PURIFIER.value,)
 
     raw: TypedAirPurifier
 

--- a/pydeconz/models/sensor/air_quality.py
+++ b/pydeconz/models/sensor/air_quality.py
@@ -3,6 +3,8 @@
 import enum
 from typing import Literal, TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -50,7 +52,7 @@ class AirQualityValue(enum.Enum):
 class AirQuality(SensorBase):
     """Air quality sensor."""
 
-    ZHATYPE = ("ZHAAirQuality",)
+    ZHATYPE = (ResourceType.ZHA_AIR_QUALITY.value,)
 
     raw: TypedAirQuality
 

--- a/pydeconz/models/sensor/alarm.py
+++ b/pydeconz/models/sensor/alarm.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedAlarm(TypedDict):
 class Alarm(SensorBase):
     """Alarm sensor."""
 
-    ZHATYPE = ("ZHAAlarm",)
+    ZHATYPE = (ResourceType.ZHA_ALARM.value,)
 
     raw: TypedAlarm
 

--- a/pydeconz/models/sensor/ancillary_control.py
+++ b/pydeconz/models/sensor/ancillary_control.py
@@ -6,6 +6,8 @@ import enum
 import logging
 from typing import Literal, TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 LOGGER = logging.getLogger(__name__)
@@ -86,7 +88,7 @@ class TypedAncillaryControl(TypedDict):
 class AncillaryControl(SensorBase):
     """Ancillary control sensor."""
 
-    ZHATYPE = ("ZHAAncillaryControl",)
+    ZHATYPE = (ResourceType.ZHA_ANCILLARY_CONTROL.value,)
 
     raw: TypedAncillaryControl
 

--- a/pydeconz/models/sensor/battery.py
+++ b/pydeconz/models/sensor/battery.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedBattery(TypedDict):
 class Battery(SensorBase):
     """Battery sensor."""
 
-    ZHATYPE = ("ZHABattery",)
+    ZHATYPE = (ResourceType.ZHA_BATTERY.value,)
 
     raw: TypedBattery
 

--- a/pydeconz/models/sensor/carbon_monoxide.py
+++ b/pydeconz/models/sensor/carbon_monoxide.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedCarbonMonoxide(TypedDict):
 class CarbonMonoxide(SensorBase):
     """Carbon monoxide sensor."""
 
-    ZHATYPE = ("ZHACarbonMonoxide",)
+    ZHATYPE = (ResourceType.ZHA_CARBON_MONOXIDE.value,)
 
     raw: TypedCarbonMonoxide
 

--- a/pydeconz/models/sensor/consumption.py
+++ b/pydeconz/models/sensor/consumption.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -23,7 +25,7 @@ class TypedConsumption(TypedDict):
 class Consumption(SensorBase):
     """Power consumption sensor."""
 
-    ZHATYPE = ("ZHAConsumption",)
+    ZHATYPE = (ResourceType.ZHA_CONSUMPTION.value,)
 
     raw: TypedConsumption
 

--- a/pydeconz/models/sensor/daylight.py
+++ b/pydeconz/models/sensor/daylight.py
@@ -2,6 +2,8 @@
 
 from typing import Final, TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 DAYLIGHT_STATUS: Final = {
@@ -47,7 +49,7 @@ class TypedDaylight(TypedDict):
 class Daylight(SensorBase):
     """Daylight sensor built into deCONZ software."""
 
-    ZHATYPE = ("Daylight",)
+    ZHATYPE = (ResourceType.DAYLIGHT.value,)
 
     raw: TypedDaylight
 

--- a/pydeconz/models/sensor/door_lock.py
+++ b/pydeconz/models/sensor/door_lock.py
@@ -3,6 +3,8 @@
 import enum
 from typing import Literal, TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -37,7 +39,7 @@ class TypedDoorLock(TypedDict):
 class DoorLock(SensorBase):
     """Door lock sensor."""
 
-    ZHATYPE = ("ZHADoorLock",)
+    ZHATYPE = (ResourceType.ZHA_DOOR_LOCK.value,)
 
     raw: TypedDoorLock
 

--- a/pydeconz/models/sensor/fire.py
+++ b/pydeconz/models/sensor/fire.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -21,7 +23,7 @@ class TypedFire(TypedDict):
 class Fire(SensorBase):
     """Fire sensor."""
 
-    ZHATYPE = ("ZHAFire",)
+    ZHATYPE = (ResourceType.ZHA_FIRE.value,)
 
     raw: TypedFire
 

--- a/pydeconz/models/sensor/generic_flag.py
+++ b/pydeconz/models/sensor/generic_flag.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedGenericFlag(TypedDict):
 class GenericFlag(SensorBase):
     """Generic flag sensor."""
 
-    ZHATYPE = ("CLIPGenericFlag",)
+    ZHATYPE = (ResourceType.CLIP_GENERIC_FLAG.value,)
 
     raw: TypedGenericFlag
 

--- a/pydeconz/models/sensor/generic_status.py
+++ b/pydeconz/models/sensor/generic_status.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedGenericStatus(TypedDict):
 class GenericStatus(SensorBase):
     """Generic status sensor."""
 
-    ZHATYPE = ("CLIPGenericStatus",)
+    ZHATYPE = (ResourceType.CLIP_GENERIC_STATUS.value,)
 
     raw: TypedGenericStatus
 

--- a/pydeconz/models/sensor/humidity.py
+++ b/pydeconz/models/sensor/humidity.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -29,7 +31,7 @@ class TypedHumidity(TypedDict):
 class Humidity(SensorBase):
     """Humidity sensor."""
 
-    ZHATYPE = ("ZHAHumidity", "CLIPHumidity")
+    ZHATYPE = (ResourceType.ZHA_HUMIDITY.value, ResourceType.CLIP_HUMIDITY.value)
 
     raw: TypedHumidity
 

--- a/pydeconz/models/sensor/light_level.py
+++ b/pydeconz/models/sensor/light_level.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -34,7 +36,7 @@ class TypedLightLevel(TypedDict):
 class LightLevel(SensorBase):
     """Light level sensor."""
 
-    ZHATYPE = ("ZHALightLevel", "CLIPLightLevel")
+    ZHATYPE = (ResourceType.ZHA_LIGHT_LEVEL.value, ResourceType.CLIP_LIGHT_LEVEL.value)
 
     raw: TypedLightLevel
 

--- a/pydeconz/models/sensor/open_close.py
+++ b/pydeconz/models/sensor/open_close.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedOpenClose(TypedDict):
 class OpenClose(SensorBase):
     """Door/Window sensor."""
 
-    ZHATYPE = ("ZHAOpenClose", "CLIPOpenClose")
+    ZHATYPE = (ResourceType.ZHA_OPEN_CLOSE.value, ResourceType.CLIP_OPEN_CLOSE.value)
 
     raw: TypedOpenClose
 

--- a/pydeconz/models/sensor/power.py
+++ b/pydeconz/models/sensor/power.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -24,7 +26,7 @@ class TypedPower(TypedDict):
 class Power(SensorBase):
     """Power sensor."""
 
-    ZHATYPE = ("ZHAPower",)
+    ZHATYPE = (ResourceType.ZHA_POWER.value,)
 
     raw: TypedPower
 

--- a/pydeconz/models/sensor/presence.py
+++ b/pydeconz/models/sensor/presence.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import enum
 from typing import Any, Final, Literal, TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 PRESENCE_DELAY: Final = "delay"
@@ -125,7 +127,7 @@ class PresenceStatePresenceEvent(enum.Enum):
 class Presence(SensorBase):
     """Presence detector."""
 
-    ZHATYPE = ("ZHAPresence", "CLIPPresence")
+    ZHATYPE = (ResourceType.ZHA_PRESENCE.value, ResourceType.CLIP_PRESENCE.value)
 
     raw: TypedPresence
 

--- a/pydeconz/models/sensor/pressure.py
+++ b/pydeconz/models/sensor/pressure.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedPressure(TypedDict):
 class Pressure(SensorBase):
     """Pressure sensor."""
 
-    ZHATYPE = ("ZHAPressure", "CLIPPressure")
+    ZHATYPE = (ResourceType.ZHA_PRESSURE.value, ResourceType.CLIP_PRESSURE.value)
 
     raw: TypedPressure
 

--- a/pydeconz/models/sensor/relative_rotary.py
+++ b/pydeconz/models/sensor/relative_rotary.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import enum
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -37,7 +39,7 @@ class RelativeRotaryEvent(enum.IntEnum):
 class RelativeRotary(SensorBase):
     """Relative rotary sensor."""
 
-    ZHATYPE = ("ZHARelativeRotary",)
+    ZHATYPE = (ResourceType.ZHA_RELATIVE_ROTARY.value,)
 
     raw: TypedRelativeRotary
 

--- a/pydeconz/models/sensor/switch.py
+++ b/pydeconz/models/sensor/switch.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import enum
 from typing import Literal, TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -69,7 +71,11 @@ class TypedSwitch(TypedDict):
 class Switch(SensorBase):
     """Switch sensor."""
 
-    ZHATYPE = ("ZHASwitch", "ZGPSwitch", "CLIPSwitch")
+    ZHATYPE = (
+        ResourceType.ZHA_SWITCH.value,
+        ResourceType.ZGP_SWITCH.value,
+        ResourceType.CLIP_SWITCH.value,
+    )
 
     raw: TypedSwitch
 

--- a/pydeconz/models/sensor/temperature.py
+++ b/pydeconz/models/sensor/temperature.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -22,7 +24,7 @@ class TypedTemperature(TypedDict):
 class Temperature(SensorBase):
     """Temperature sensor."""
 
-    ZHATYPE = ("ZHATemperature", "CLIPTemperature")
+    ZHATYPE = (ResourceType.ZHA_TEMPERATURE.value, ResourceType.CLIP_TEMPERATURE.value)
 
     raw: TypedTemperature
 

--- a/pydeconz/models/sensor/thermostat.py
+++ b/pydeconz/models/sensor/thermostat.py
@@ -6,6 +6,8 @@ import enum
 import logging
 from typing import Literal, TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 LOGGER = logging.getLogger(__name__)
@@ -207,7 +209,7 @@ class TypedThermostat(TypedDict):
 class Thermostat(SensorBase):
     """Thermostat "sensor"."""
 
-    ZHATYPE = ("ZHAThermostat", "CLIPThermostat")
+    ZHATYPE = (ResourceType.ZHA_THERMOSTAT.value, ResourceType.CLIP_THERMOSTAT.value)
 
     raw: TypedThermostat
 

--- a/pydeconz/models/sensor/time.py
+++ b/pydeconz/models/sensor/time.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedTime(TypedDict):
 class Time(SensorBase):
     """Time sensor."""
 
-    ZHATYPE = ("ZHATime",)
+    ZHATYPE = (ResourceType.ZHA_TIME.value,)
 
     raw: TypedTime
 

--- a/pydeconz/models/sensor/vibration.py
+++ b/pydeconz/models/sensor/vibration.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -33,7 +35,7 @@ class TypedVibration(TypedDict):
 class Vibration(SensorBase):
     """Vibration sensor."""
 
-    ZHATYPE = ("ZHAVibration",)
+    ZHATYPE = (ResourceType.ZHA_VIBRATION.value,)
 
     raw: TypedVibration
 

--- a/pydeconz/models/sensor/water.py
+++ b/pydeconz/models/sensor/water.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from pydeconz.models import ResourceType
+
 from . import SensorBase
 
 
@@ -20,7 +22,7 @@ class TypedWater(TypedDict):
 class Water(SensorBase):
     """Water sensor."""
 
-    ZHATYPE = ("ZHAWater",)
+    ZHATYPE = (ResourceType.ZHA_WATER.value,)
 
     raw: TypedWater
 

--- a/tests/sensors/test_air_purifier.py
+++ b/tests/sensors/test_air_purifier.py
@@ -5,6 +5,34 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 
 from pydeconz.models.sensor.air_purifier import AirPurifierFanMode
 
+DATA = {
+    "config": {
+        "filterlifetime": 256728,
+        "ledindication": True,
+        "locked": False,
+        "mode": "auto",
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "fea6623ea3909029409fed7a6224e60b",
+    "lastannounced": None,
+    "lastseen": "2022-06-30T18:19Z",
+    "manufacturername": "IKEA of Sweden",
+    "modelid": "STARKVIND Air purifier",
+    "name": "Starkvind",
+    "state": {
+        "deviceruntime": 185310,
+        "filterruntime": 182857,
+        "lastupdated": "2022-06-11T15:39:46.328",
+        "replacefilter": False,
+        "speed": 20,
+    },
+    "swversion": "1.0.033",
+    "type": "ZHAAirPurifier",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-fc7d",
+}
+
 
 async def test_handler_air_purifier(
     mock_aioresponse, deconz_session, deconz_called_with
@@ -40,35 +68,7 @@ async def test_handler_air_purifier(
 
 async def test_sensor_air_purifier(deconz_sensor):
     """Verify that air purifier sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "filterlifetime": 256728,
-                "ledindication": True,
-                "locked": False,
-                "mode": "auto",
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "fea6623ea3909029409fed7a6224e60b",
-            "lastannounced": None,
-            "lastseen": "2022-06-30T18:19Z",
-            "manufacturername": "IKEA of Sweden",
-            "modelid": "STARKVIND Air purifier",
-            "name": "Starkvind",
-            "state": {
-                "deviceruntime": 185310,
-                "filterruntime": 182857,
-                "lastupdated": "2022-06-11T15:39:46.328",
-                "replacefilter": False,
-                "speed": 20,
-            },
-            "swversion": "1.0.033",
-            "type": "ZHAAirPurifier",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-fc7d",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAAirPurifier",)
 

--- a/tests/sensors/test_air_purifier.py
+++ b/tests/sensors/test_air_purifier.py
@@ -6,7 +6,7 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 from pydeconz.models.sensor.air_purifier import AirPurifierFanMode
 
 
-async def test_control_air_purifier(
+async def test_handler_air_purifier(
     mock_aioresponse, deconz_session, deconz_called_with
 ):
     """Verify that air purifier controls works."""
@@ -38,7 +38,7 @@ async def test_control_air_purifier(
     )
 
 
-async def test_air_purifier_sensor(deconz_sensor):
+async def test_sensor_air_purifier(deconz_sensor):
     """Verify that air purifier sensor works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_air_quality.py
+++ b/tests/sensors/test_air_quality.py
@@ -6,7 +6,7 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 from pydeconz.models.sensor.air_quality import AirQualityValue
 
 
-async def test_air_quality_sensor(deconz_sensor):
+async def test_sensor_air_quality(deconz_sensor):
     """Verify that air quality sensor works."""
     sensor = await deconz_sensor(
         {
@@ -55,7 +55,7 @@ async def test_air_quality_sensor(deconz_sensor):
     assert sensor.unique_id == "00:12:4b:00:14:4d:00:07-02-fdef"
 
 
-async def test_air_quality_sensor_with_pm2_5(deconz_sensor):
+async def test_sensor_air_quality_with_pm2_5(deconz_sensor):
     """Verify that air quality with PM 2.5 sensor works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_air_quality.py
+++ b/tests/sensors/test_air_quality.py
@@ -5,28 +5,53 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 
 from pydeconz.models.sensor.air_quality import AirQualityValue
 
+DATA = {
+    "config": {
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 2,
+    "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
+    "lastseen": "2020-11-20T22:48Z",
+    "manufacturername": "BOSCH",
+    "modelid": "AIR",
+    "name": "BOSCH Air quality sensor",
+    "state": {
+        "airquality": "poor",
+        "airqualityppb": 809,
+        "lastupdated": "2020-11-20T22:48:00.209",
+    },
+    "swversion": "20200402",
+    "type": "ZHAAirQuality",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-fdef",
+}
+
+DATA_WITH_PM25 = {
+    "config": {
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "74eb5d8558a3895a39a3884189701c99",
+    "lastannounced": None,
+    "lastseen": "2022-06-30T18:20Z",
+    "manufacturername": "IKEA of Sweden",
+    "modelid": "STARKVIND Air purifier",
+    "name": "Starkvind",
+    "state": {
+        "airquality": "excellent",
+        "lastupdated": "2022-06-30T18:18:26.205",
+        "pm2_5": 8,
+    },
+    "swversion": "1.0.033",
+    "type": "ZHAAirQuality",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-fc7d",
+}
+
 
 async def test_sensor_air_quality(deconz_sensor):
     """Verify that air quality sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "ep": 2,
-            "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
-            "lastseen": "2020-11-20T22:48Z",
-            "manufacturername": "BOSCH",
-            "modelid": "AIR",
-            "name": "BOSCH Air quality sensor",
-            "state": {
-                "airquality": "poor",
-                "airqualityppb": 809,
-                "lastupdated": "2020-11-20T22:48:00.209",
-            },
-            "swversion": "20200402",
-            "type": "ZHAAirQuality",
-            "uniqueid": "00:12:4b:00:14:4d:00:07-02-fdef",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAAirQuality",)
 
@@ -52,31 +77,12 @@ async def test_sensor_air_quality(deconz_sensor):
     assert sensor.name == "BOSCH Air quality sensor"
     assert sensor.software_version == "20200402"
     assert sensor.type == "ZHAAirQuality"
-    assert sensor.unique_id == "00:12:4b:00:14:4d:00:07-02-fdef"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-02-fdef"
 
 
 async def test_sensor_air_quality_with_pm2_5(deconz_sensor):
     """Verify that air quality with PM 2.5 sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "ep": 1,
-            "etag": "74eb5d8558a3895a39a3884189701c99",
-            "lastannounced": None,
-            "lastseen": "2022-06-30T18:20Z",
-            "manufacturername": "IKEA of Sweden",
-            "modelid": "STARKVIND Air purifier",
-            "name": "Starkvind",
-            "state": {
-                "airquality": "excellent",
-                "lastupdated": "2022-06-30T18:18:26.205",
-                "pm2_5": 8,
-            },
-            "swversion": "1.0.033",
-            "type": "ZHAAirQuality",
-            "uniqueid": "cc:86:ec:ff:fe:6d:30:11-02-fc7d",
-        }
-    )
+    sensor = await deconz_sensor(DATA_WITH_PM25)
 
     assert sensor.ZHATYPE == ("ZHAAirQuality",)
 

--- a/tests/sensors/test_alarm.py
+++ b/tests/sensors/test_alarm.py
@@ -3,33 +3,33 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.alarm tests/sensors/test_alarm.py
 """
 
+DATA = {
+    "config": {
+        "battery": 100,
+        "on": True,
+        "reachable": True,
+        "temperature": 2600,
+    },
+    "ep": 1,
+    "etag": "18c0f3c2100904e31a7f938db2ba9ba9",
+    "manufacturername": "dresden elektronik",
+    "modelid": "lumi.sensor_motion.aq2",
+    "name": "Alarm 10",
+    "state": {
+        "alarm": False,
+        "lastupdated": "none",
+        "lowbattery": None,
+        "tampered": None,
+    },
+    "swversion": "20170627",
+    "type": "ZHAAlarm",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
+}
+
 
 async def test_sensor_alarm(deconz_sensor):
     """Verify that alarm sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "on": True,
-                "reachable": True,
-                "temperature": 2600,
-            },
-            "ep": 1,
-            "etag": "18c0f3c2100904e31a7f938db2ba9ba9",
-            "manufacturername": "dresden elektronik",
-            "modelid": "lumi.sensor_motion.aq2",
-            "name": "Alarm 10",
-            "state": {
-                "alarm": False,
-                "lastupdated": "none",
-                "lowbattery": None,
-                "tampered": None,
-            },
-            "swversion": "20170627",
-            "type": "ZHAAlarm",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAAlarm",)
 

--- a/tests/sensors/test_alarm.py
+++ b/tests/sensors/test_alarm.py
@@ -1,0 +1,55 @@
+"""Test pydeCONZ alarm.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.alarm tests/sensors/test_alarm.py
+"""
+
+
+async def test_sensor_alarm(deconz_sensor):
+    """Verify that alarm sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {
+                "battery": 100,
+                "on": True,
+                "reachable": True,
+                "temperature": 2600,
+            },
+            "ep": 1,
+            "etag": "18c0f3c2100904e31a7f938db2ba9ba9",
+            "manufacturername": "dresden elektronik",
+            "modelid": "lumi.sensor_motion.aq2",
+            "name": "Alarm 10",
+            "state": {
+                "alarm": False,
+                "lastupdated": "none",
+                "lowbattery": None,
+                "tampered": None,
+            },
+            "swversion": "20170627",
+            "type": "ZHAAlarm",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAAlarm",)
+
+    assert sensor.alarm is False
+
+    # DeconzSensor
+    assert sensor.battery == 100
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature == 26
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "18c0f3c2100904e31a7f938db2ba9ba9"
+    assert sensor.manufacturer == "dresden elektronik"
+    assert sensor.model_id == "lumi.sensor_motion.aq2"
+    assert sensor.name == "Alarm 10"
+    assert sensor.software_version == "20170627"
+    assert sensor.type == "ZHAAlarm"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0500"

--- a/tests/sensors/test_ancillary_control.py
+++ b/tests/sensors/test_ancillary_control.py
@@ -11,7 +11,7 @@ from pydeconz.models.sensor.ancillary_control import (
 )
 
 
-async def test_ancillary_control_sensor(deconz_sensor):
+async def test_sensor_ancillary_control(deconz_sensor):
     """Verify that ancillary control sensor works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_ancillary_control.py
+++ b/tests/sensors/test_ancillary_control.py
@@ -10,37 +10,37 @@ from pydeconz.models.sensor.ancillary_control import (
     AncillaryControlPanel,
 )
 
+DATA = {
+    "config": {
+        "battery": 95,
+        "enrolled": 1,
+        "on": True,
+        "pending": [],
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
+    "lastseen": "2021-07-25T18:07Z",
+    "manufacturername": "lk",
+    "modelid": "ZB-KeypadGeneric-D0002",
+    "name": "Keypad",
+    "state": {
+        "action": "armed_stay",
+        "lastupdated": "2021-07-25T18:02:51.172",
+        "lowbattery": False,
+        "panel": "exit_delay",
+        "seconds_remaining": 55,
+        "tampered": False,
+    },
+    "swversion": "3.13",
+    "type": "ZHAAncillaryControl",
+    "uniqueid": "ec:1b:bd:ff:fe:6f:c3:4d-01-0501",
+}
+
 
 async def test_sensor_ancillary_control(deconz_sensor):
     """Verify that ancillary control sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 95,
-                "enrolled": 1,
-                "on": True,
-                "pending": [],
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
-            "lastseen": "2021-07-25T18:07Z",
-            "manufacturername": "lk",
-            "modelid": "ZB-KeypadGeneric-D0002",
-            "name": "Keypad",
-            "state": {
-                "action": "armed_stay",
-                "lastupdated": "2021-07-25T18:02:51.172",
-                "lowbattery": False,
-                "panel": "exit_delay",
-                "seconds_remaining": 55,
-                "tampered": False,
-            },
-            "swversion": "3.13",
-            "type": "ZHAAncillaryControl",
-            "uniqueid": "ec:1b:bd:ff:fe:6f:c3:4d-01-0501",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAAncillaryControl",)
 

--- a/tests/sensors/test_battery.py
+++ b/tests/sensors/test_battery.py
@@ -1,0 +1,43 @@
+"""Test pydeCONZ battery.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.battery tests/sensors/test_battery.py
+"""
+
+
+async def test_sensor_battery(deconz_sensor):
+    """Verify that alarm sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"alert": "none", "on": True, "reachable": True},
+            "ep": 1,
+            "etag": "23a8659f1cb22df2f51bc2da0e241bb4",
+            "manufacturername": "IKEA of Sweden",
+            "modelid": "FYRTUR block-out roller blind",
+            "name": "FYRTUR block-out roller blind",
+            "state": {"battery": 100, "lastupdated": "none"},
+            "swversion": "2.2.007",
+            "type": "ZHABattery",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0001",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHABattery",)
+
+    # DeconzSensor
+    assert sensor.battery == 100
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "23a8659f1cb22df2f51bc2da0e241bb4"
+    assert sensor.manufacturer == "IKEA of Sweden"
+    assert sensor.model_id == "FYRTUR block-out roller blind"
+    assert sensor.name == "FYRTUR block-out roller blind"
+    assert sensor.software_version == "2.2.007"
+    assert sensor.type == "ZHABattery"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0001"

--- a/tests/sensors/test_battery.py
+++ b/tests/sensors/test_battery.py
@@ -3,23 +3,30 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.battery tests/sensors/test_battery.py
 """
 
+DATA = {
+    "config": {
+        "alert": "none",
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "23a8659f1cb22df2f51bc2da0e241bb4",
+    "manufacturername": "IKEA of Sweden",
+    "modelid": "FYRTUR block-out roller blind",
+    "name": "FYRTUR block-out roller blind",
+    "state": {
+        "battery": 100,
+        "lastupdated": "none",
+    },
+    "swversion": "2.2.007",
+    "type": "ZHABattery",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0001",
+}
+
 
 async def test_sensor_battery(deconz_sensor):
     """Verify that alarm sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"alert": "none", "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "23a8659f1cb22df2f51bc2da0e241bb4",
-            "manufacturername": "IKEA of Sweden",
-            "modelid": "FYRTUR block-out roller blind",
-            "name": "FYRTUR block-out roller blind",
-            "state": {"battery": 100, "lastupdated": "none"},
-            "swversion": "2.2.007",
-            "type": "ZHABattery",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0001",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHABattery",)
 

--- a/tests/sensors/test_carbon_monoxide.py
+++ b/tests/sensors/test_carbon_monoxide.py
@@ -3,33 +3,33 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.carbon_monoxide tests/sensors/test_carbon_monoxide.py
 """
 
+DATA = {
+    "config": {
+        "battery": 100,
+        "on": True,
+        "pending": [],
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "b7599df551944df97b2aa87d160b9c45",
+    "manufacturername": "Heiman",
+    "modelid": "CO_V16",
+    "name": "Cave, CO",
+    "state": {
+        "carbonmonoxide": False,
+        "lastupdated": "none",
+        "lowbattery": False,
+        "tampered": False,
+    },
+    "swversion": "20150330",
+    "type": "ZHACarbonMonoxide",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
+}
+
 
 async def test_sensor_carbon_monoxide(deconz_sensor):
     """Verify that carbon monoxide sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "on": True,
-                "pending": [],
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "b7599df551944df97b2aa87d160b9c45",
-            "manufacturername": "Heiman",
-            "modelid": "CO_V16",
-            "name": "Cave, CO",
-            "state": {
-                "carbonmonoxide": False,
-                "lastupdated": "none",
-                "lowbattery": False,
-                "tampered": False,
-            },
-            "swversion": "20150330",
-            "type": "ZHACarbonMonoxide",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHACarbonMonoxide",)
 

--- a/tests/sensors/test_carbon_monoxide.py
+++ b/tests/sensors/test_carbon_monoxide.py
@@ -1,0 +1,55 @@
+"""Test pydeCONZ carbon monoxide sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.carbon_monoxide tests/sensors/test_carbon_monoxide.py
+"""
+
+
+async def test_sensor_carbon_monoxide(deconz_sensor):
+    """Verify that carbon monoxide sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {
+                "battery": 100,
+                "on": True,
+                "pending": [],
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "b7599df551944df97b2aa87d160b9c45",
+            "manufacturername": "Heiman",
+            "modelid": "CO_V16",
+            "name": "Cave, CO",
+            "state": {
+                "carbonmonoxide": False,
+                "lastupdated": "none",
+                "lowbattery": False,
+                "tampered": False,
+            },
+            "swversion": "20150330",
+            "type": "ZHACarbonMonoxide",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHACarbonMonoxide",)
+
+    assert sensor.carbon_monoxide is False
+
+    # DeconzSensor
+    assert sensor.battery == 100
+    assert sensor.ep == 1
+    assert sensor.low_battery is False
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is False
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "b7599df551944df97b2aa87d160b9c45"
+    assert sensor.manufacturer == "Heiman"
+    assert sensor.model_id == "CO_V16"
+    assert sensor.name == "Cave, CO"
+    assert sensor.software_version == "20150330"
+    assert sensor.type == "ZHACarbonMonoxide"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0101"

--- a/tests/sensors/test_consumption.py
+++ b/tests/sensors/test_consumption.py
@@ -3,26 +3,29 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.consumption tests/sensors/test_consumption.py
 """
 
+DATA = {
+    "config": {
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "a99e5bc463d15c23af7e89946e784cca",
+    "manufacturername": "Heiman",
+    "modelid": "SmartPlug",
+    "name": "Consumption 15",
+    "state": {
+        "consumption": 11342,
+        "lastupdated": "2018-03-12T19:19:08",
+        "power": 123,
+    },
+    "type": "ZHAConsumption",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0702",
+}
+
 
 async def test_sensor_consumption(deconz_sensor):
     """Verify that consumption sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "ep": 1,
-            "etag": "a99e5bc463d15c23af7e89946e784cca",
-            "manufacturername": "Heiman",
-            "modelid": "SmartPlug",
-            "name": "Consumption 15",
-            "state": {
-                "consumption": 11342,
-                "lastupdated": "2018-03-12T19:19:08",
-                "power": 123,
-            },
-            "type": "ZHAConsumption",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0702",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAConsumption",)
 

--- a/tests/sensors/test_consumption.py
+++ b/tests/sensors/test_consumption.py
@@ -1,0 +1,50 @@
+"""Test pydeCONZ consumption sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.consumption tests/sensors/test_consumption.py
+"""
+
+
+async def test_sensor_consumption(deconz_sensor):
+    """Verify that consumption sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"on": True, "reachable": True},
+            "ep": 1,
+            "etag": "a99e5bc463d15c23af7e89946e784cca",
+            "manufacturername": "Heiman",
+            "modelid": "SmartPlug",
+            "name": "Consumption 15",
+            "state": {
+                "consumption": 11342,
+                "lastupdated": "2018-03-12T19:19:08",
+                "power": 123,
+            },
+            "type": "ZHAConsumption",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0702",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAConsumption",)
+
+    assert sensor.consumption == 11342
+    assert sensor.power == 123
+    assert sensor.scaled_consumption == 11.342
+
+    # DeconzSensor
+    assert sensor.battery is None
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "a99e5bc463d15c23af7e89946e784cca"
+    assert sensor.manufacturer == "Heiman"
+    assert sensor.model_id == "SmartPlug"
+    assert sensor.name == "Consumption 15"
+    assert sensor.software_version == ""
+    assert sensor.type == "ZHAConsumption"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0702"

--- a/tests/sensors/test_daylight.py
+++ b/tests/sensors/test_daylight.py
@@ -3,30 +3,30 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.daylight tests/sensors/test_daylight.py
 """
 
+DATA = {
+    "config": {
+        "configured": True,
+        "on": True,
+        "sunriseoffset": 30,
+        "sunsetoffset": -30,
+    },
+    "etag": "55047cf652a7e594d0ee7e6fae01dd38",
+    "manufacturername": "Philips",
+    "modelid": "PHDL00",
+    "name": "Daylight",
+    "state": {
+        "daylight": True,
+        "lastupdated": "2018-03-24T17:26:12",
+        "status": 170,
+    },
+    "swversion": "1.0",
+    "type": "Daylight",
+}
+
 
 async def test_sensor_daylight(deconz_sensor):
     """Verify that daylight sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "configured": True,
-                "on": True,
-                "sunriseoffset": 30,
-                "sunsetoffset": -30,
-            },
-            "etag": "55047cf652a7e594d0ee7e6fae01dd38",
-            "manufacturername": "Philips",
-            "modelid": "PHDL00",
-            "name": "Daylight",
-            "state": {
-                "daylight": True,
-                "lastupdated": "2018-03-24T17:26:12",
-                "status": 170,
-            },
-            "swversion": "1.0",
-            "type": "Daylight",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("Daylight",)
 

--- a/tests/sensors/test_daylight.py
+++ b/tests/sensors/test_daylight.py
@@ -1,0 +1,80 @@
+"""Test pydeCONZ daylight sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.daylight tests/sensors/test_daylight.py
+"""
+
+
+async def test_sensor_daylight(deconz_sensor):
+    """Verify that daylight sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {
+                "configured": True,
+                "on": True,
+                "sunriseoffset": 30,
+                "sunsetoffset": -30,
+            },
+            "etag": "55047cf652a7e594d0ee7e6fae01dd38",
+            "manufacturername": "Philips",
+            "modelid": "PHDL00",
+            "name": "Daylight",
+            "state": {
+                "daylight": True,
+                "lastupdated": "2018-03-24T17:26:12",
+                "status": 170,
+            },
+            "swversion": "1.0",
+            "type": "Daylight",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("Daylight",)
+
+    assert sensor.configured is True
+    assert sensor.daylight is True
+    assert sensor.status == "solar_noon"
+    assert sensor.sunrise_offset == 30
+    assert sensor.sunset_offset == -30
+
+    # DeconzSensor
+    assert sensor.battery is None
+    assert sensor.ep is None
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "55047cf652a7e594d0ee7e6fae01dd38"
+    assert sensor.manufacturer == "Philips"
+    assert sensor.model_id == "PHDL00"
+    assert sensor.name == "Daylight"
+    assert sensor.software_version == "1.0"
+    assert sensor.type == "Daylight"
+    assert sensor.unique_id == ""
+
+    statuses = {
+        100: "nadir",
+        110: "night_end",
+        120: "nautical_dawn",
+        130: "dawn",
+        140: "sunrise_start",
+        150: "sunrise_end",
+        160: "golden_hour_1",
+        170: "solar_noon",
+        180: "golden_hour_2",
+        190: "sunset_start",
+        200: "sunset_end",
+        210: "dusk",
+        220: "nautical_dusk",
+        230: "night_start",
+        0: "unknown",
+    }
+
+    for k, v in statuses.items():
+        event = {"state": {"status": k}}
+        sensor.update(event)
+
+        assert sensor.changed_keys == {"state", "status"}

--- a/tests/sensors/test_door_lock.py
+++ b/tests/sensors/test_door_lock.py
@@ -5,6 +5,28 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 
 from pydeconz.models.sensor.door_lock import DoorLockLockState
 
+DATA = {
+    "config": {
+        "battery": 100,
+        "lock": False,
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 11,
+    "etag": "a43862f76b7fa48b0fbb9107df123b0e",
+    "lastseen": "2021-03-06T22:25Z",
+    "manufacturername": "Onesti Products AS",
+    "modelid": "easyCodeTouch_v1",
+    "name": "easyCodeTouch_v1",
+    "state": {
+        "lastupdated": "2021-03-06T21:25:45.624",
+        "lockstate": "unlocked",
+    },
+    "swversion": "20201211",
+    "type": "ZHADoorLock",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-xx-0101",
+}
+
 
 async def test_handler_door_lock(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that door lock sensor works."""
@@ -21,29 +43,7 @@ async def test_handler_door_lock(mock_aioresponse, deconz_session, deconz_called
 
 async def test_sensor_door_lock(deconz_sensor):
     """Verify that door lock sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "lock": False,
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 11,
-            "etag": "a43862f76b7fa48b0fbb9107df123b0e",
-            "lastseen": "2021-03-06T22:25Z",
-            "manufacturername": "Onesti Products AS",
-            "modelid": "easyCodeTouch_v1",
-            "name": "easyCodeTouch_v1",
-            "state": {
-                "lastupdated": "2021-03-06T21:25:45.624",
-                "lockstate": "unlocked",
-            },
-            "swversion": "20201211",
-            "type": "ZHADoorLock",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-xx-0101",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHADoorLock",)
 

--- a/tests/sensors/test_door_lock.py
+++ b/tests/sensors/test_door_lock.py
@@ -6,7 +6,7 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 from pydeconz.models.sensor.door_lock import DoorLockLockState
 
 
-async def test_control_door_lock(mock_aioresponse, deconz_session, deconz_called_with):
+async def test_handler_door_lock(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that door lock sensor works."""
     locks = deconz_session.sensors.door_lock
 
@@ -19,7 +19,7 @@ async def test_control_door_lock(mock_aioresponse, deconz_session, deconz_called
     assert deconz_called_with("put", path="/sensors/0/config", json={"lock": False})
 
 
-async def test_door_lock_sensor(deconz_sensor):
+async def test_sensor_door_lock(deconz_sensor):
     """Verify that door lock sensor works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_fire.py
+++ b/tests/sensors/test_fire.py
@@ -3,22 +3,50 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.fire tests/sensors/test_fire.py
 """
 
+DATA = {
+    "config": {
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "2b585d2c016bfd665ba27a8fdad28670",
+    "manufacturername": "LUMI",
+    "modelid": "lumi.sensor_smoke",
+    "name": "sensor_kitchen_smoke",
+    "state": {
+        "fire": False,
+        "lastupdated": "2018-02-20T11:25:02",
+    },
+    "type": "ZHAFire",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
+}
+
+DATA_DEVELCO = {
+    "config": {
+        "on": True,
+        "battery": 90,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "abcdef1234567890abcdef1234567890",
+    "manufacturername": "frient A/S",
+    "modelid": "SMSZB-120",
+    "name": "Fire alarm",
+    "state": {
+        "fire": False,
+        "lastupdated": "2021-11-25T08:00:02.003",
+        "lowbattery": False,
+        "test": True,
+    },
+    "swversion": "20210526 05:57",
+    "type": "ZHAFire",
+    "uniqueid": "00:11:22:33:44:55:66:77-88-9900",
+}
+
 
 async def test_sensor_fire(deconz_sensor):
     """Verify that fire sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "ep": 1,
-            "etag": "2b585d2c016bfd665ba27a8fdad28670",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.sensor_smoke",
-            "name": "sensor_kitchen_smoke",
-            "state": {"fire": False, "lastupdated": "2018-02-20T11:25:02"},
-            "type": "ZHAFire",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAFire",)
 
@@ -45,27 +73,9 @@ async def test_sensor_fire(deconz_sensor):
     assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0500"
 
 
-async def test_fire_sensor_test_develco(deconz_sensor):
+async def test_sensor_fire_develco(deconz_sensor):
     """Verify that develco/frient fire sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "battery": 90, "reachable": True},
-            "ep": 1,
-            "etag": "abcdef1234567890abcdef1234567890",
-            "manufacturername": "frient A/S",
-            "modelid": "SMSZB-120",
-            "name": "Fire alarm",
-            "state": {
-                "fire": False,
-                "lastupdated": "2021-11-25T08:00:02.003",
-                "lowbattery": False,
-                "test": True,
-            },
-            "swversion": "20210526 05:57",
-            "type": "ZHAFire",
-            "uniqueid": "00:11:22:33:44:55:66:77-88-9900",
-        }
-    )
+    sensor = await deconz_sensor(DATA_DEVELCO)
 
     assert sensor.ZHATYPE == ("ZHAFire",)
 

--- a/tests/sensors/test_fire.py
+++ b/tests/sensors/test_fire.py
@@ -1,0 +1,92 @@
+"""Test pydeCONZ fire sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.fire tests/sensors/test_fire.py
+"""
+
+
+async def test_sensor_fire(deconz_sensor):
+    """Verify that fire sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"on": True, "reachable": True},
+            "ep": 1,
+            "etag": "2b585d2c016bfd665ba27a8fdad28670",
+            "manufacturername": "LUMI",
+            "modelid": "lumi.sensor_smoke",
+            "name": "sensor_kitchen_smoke",
+            "state": {"fire": False, "lastupdated": "2018-02-20T11:25:02"},
+            "type": "ZHAFire",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAFire",)
+
+    assert sensor.fire is False
+
+    # DeconzSensor
+    assert sensor.battery is None
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.in_test_mode is False
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "2b585d2c016bfd665ba27a8fdad28670"
+    assert sensor.manufacturer == "LUMI"
+    assert sensor.model_id == "lumi.sensor_smoke"
+    assert sensor.name == "sensor_kitchen_smoke"
+    assert sensor.software_version == ""
+    assert sensor.type == "ZHAFire"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0500"
+
+
+async def test_fire_sensor_test_develco(deconz_sensor):
+    """Verify that develco/frient fire sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"on": True, "battery": 90, "reachable": True},
+            "ep": 1,
+            "etag": "abcdef1234567890abcdef1234567890",
+            "manufacturername": "frient A/S",
+            "modelid": "SMSZB-120",
+            "name": "Fire alarm",
+            "state": {
+                "fire": False,
+                "lastupdated": "2021-11-25T08:00:02.003",
+                "lowbattery": False,
+                "test": True,
+            },
+            "swversion": "20210526 05:57",
+            "type": "ZHAFire",
+            "uniqueid": "00:11:22:33:44:55:66:77-88-9900",
+        }
+    )
+
+    assert sensor.ZHATYPE == ("ZHAFire",)
+
+    assert sensor.fire is False
+
+    # DeconzSensor
+    assert sensor.battery == 90
+    assert sensor.ep == 1
+    assert sensor.low_battery is False
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.in_test_mode is True
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "abcdef1234567890abcdef1234567890"
+    assert sensor.manufacturer == "frient A/S"
+    assert sensor.model_id == "SMSZB-120"
+    assert sensor.name == "Fire alarm"
+    assert sensor.software_version == "20210526 05:57"
+    assert sensor.type == "ZHAFire"
+    assert sensor.unique_id == "00:11:22:33:44:55:66:77-88-9900"

--- a/tests/sensors/test_generic_flag.py
+++ b/tests/sensors/test_generic_flag.py
@@ -1,0 +1,42 @@
+"""Test pydeCONZ generic flag sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.generic_flag tests/sensors/test_generic_flag.py
+"""
+
+
+async def test_sensor_generic_flag(deconz_sensor):
+    """Verify that generic flag sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"on": True, "reachable": True},
+            "modelid": "Switch",
+            "name": "Kitchen Switch",
+            "state": {"flag": True, "lastupdated": "2018-07-01T10:40:35"},
+            "swversion": "1.0.0",
+            "type": "CLIPGenericFlag",
+            "uniqueid": "kitchen-switch",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("CLIPGenericFlag",)
+
+    assert sensor.flag is True
+
+    # DeconzSensor
+    assert sensor.battery is None
+    assert sensor.ep is None
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == ""
+    assert sensor.manufacturer == ""
+    assert sensor.model_id == "Switch"
+    assert sensor.name == "Kitchen Switch"
+    assert sensor.software_version == "1.0.0"
+    assert sensor.type == "CLIPGenericFlag"
+    assert sensor.unique_id == "kitchen-switch"

--- a/tests/sensors/test_generic_flag.py
+++ b/tests/sensors/test_generic_flag.py
@@ -3,20 +3,26 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.generic_flag tests/sensors/test_generic_flag.py
 """
 
+DATA = {
+    "config": {
+        "on": True,
+        "reachable": True,
+    },
+    "modelid": "Switch",
+    "name": "Kitchen Switch",
+    "state": {
+        "flag": True,
+        "lastupdated": "2018-07-01T10:40:35",
+    },
+    "swversion": "1.0.0",
+    "type": "CLIPGenericFlag",
+    "uniqueid": "kitchen-switch",
+}
+
 
 async def test_sensor_generic_flag(deconz_sensor):
     """Verify that generic flag sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "modelid": "Switch",
-            "name": "Kitchen Switch",
-            "state": {"flag": True, "lastupdated": "2018-07-01T10:40:35"},
-            "swversion": "1.0.0",
-            "type": "CLIPGenericFlag",
-            "uniqueid": "kitchen-switch",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("CLIPGenericFlag",)
 

--- a/tests/sensors/test_generic_status.py
+++ b/tests/sensors/test_generic_status.py
@@ -1,0 +1,44 @@
+"""Test pydeCONZ generic status sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.generic_status tests/sensors/test_generic_status.py
+"""
+
+
+async def test_sensor_generic_status(deconz_sensor):
+    """Verify that generic flag sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"on": True, "reachable": True},
+            "etag": "aacc83bc7d6e4af7e44014e9f776b206",
+            "manufacturername": "Phoscon",
+            "modelid": "PHOSCON_FSM_STATE",
+            "name": "FSM_STATE Motion stair",
+            "state": {"lastupdated": "2019-04-24T00:00:25", "status": 0},
+            "swversion": "1.0",
+            "type": "CLIPGenericStatus",
+            "uniqueid": "fsm-state-1520195376277",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("CLIPGenericStatus",)
+
+    assert sensor.status == 0
+
+    # DeconzSensor
+    assert sensor.battery is None
+    assert sensor.ep is None
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "aacc83bc7d6e4af7e44014e9f776b206"
+    assert sensor.manufacturer == "Phoscon"
+    assert sensor.model_id == "PHOSCON_FSM_STATE"
+    assert sensor.name == "FSM_STATE Motion stair"
+    assert sensor.software_version == "1.0"
+    assert sensor.type == "CLIPGenericStatus"
+    assert sensor.unique_id == "fsm-state-1520195376277"

--- a/tests/sensors/test_generic_status.py
+++ b/tests/sensors/test_generic_status.py
@@ -3,22 +3,28 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.generic_status tests/sensors/test_generic_status.py
 """
 
+DATA = {
+    "config": {
+        "on": True,
+        "reachable": True,
+    },
+    "etag": "aacc83bc7d6e4af7e44014e9f776b206",
+    "manufacturername": "Phoscon",
+    "modelid": "PHOSCON_FSM_STATE",
+    "name": "FSM_STATE Motion stair",
+    "state": {
+        "lastupdated": "2019-04-24T00:00:25",
+        "status": 0,
+    },
+    "swversion": "1.0",
+    "type": "CLIPGenericStatus",
+    "uniqueid": "fsm-state-1520195376277",
+}
+
 
 async def test_sensor_generic_status(deconz_sensor):
     """Verify that generic flag sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "etag": "aacc83bc7d6e4af7e44014e9f776b206",
-            "manufacturername": "Phoscon",
-            "modelid": "PHOSCON_FSM_STATE",
-            "name": "FSM_STATE Motion stair",
-            "state": {"lastupdated": "2019-04-24T00:00:25", "status": 0},
-            "swversion": "1.0",
-            "type": "CLIPGenericStatus",
-            "uniqueid": "fsm-state-1520195376277",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("CLIPGenericStatus",)
 

--- a/tests/sensors/test_humidity.py
+++ b/tests/sensors/test_humidity.py
@@ -3,6 +3,27 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.humidity tests/sensors/test_humidity.py
 """
 
+DATA = {
+    "config": {
+        "battery": 100,
+        "offset": 0,
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "1220e5d026493b6e86207993703a8a71",
+    "manufacturername": "LUMI",
+    "modelid": "lumi.weather",
+    "name": "Mi temperature 1",
+    "state": {
+        "humidity": 3555,
+        "lastupdated": "2019-05-05T14:39:00",
+    },
+    "swversion": "20161129",
+    "type": "ZHAHumidity",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0405",
+}
+
 
 async def test_handler_humidity(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that humidity sensor works."""
@@ -15,20 +36,7 @@ async def test_handler_humidity(mock_aioresponse, deconz_session, deconz_called_
 
 async def test_sensor_humidity(deconz_sensor):
     """Verify that humidity sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"battery": 100, "offset": 0, "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "1220e5d026493b6e86207993703a8a71",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.weather",
-            "name": "Mi temperature 1",
-            "state": {"humidity": 3555, "lastupdated": "2019-05-05T14:39:00"},
-            "swversion": "20161129",
-            "type": "ZHAHumidity",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0405",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAHumidity", "CLIPHumidity")
 

--- a/tests/sensors/test_humidity.py
+++ b/tests/sensors/test_humidity.py
@@ -4,7 +4,7 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 """
 
 
-async def test_configure_humidity(mock_aioresponse, deconz_session, deconz_called_with):
+async def test_handler_humidity(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that humidity sensor works."""
     humidity = deconz_session.sensors.humidity
 
@@ -13,7 +13,7 @@ async def test_configure_humidity(mock_aioresponse, deconz_session, deconz_calle
     assert deconz_called_with("put", path="/sensors/0/config", json={"offset": 1})
 
 
-async def test_humidity_sensor(deconz_sensor):
+async def test_sensor_humidity(deconz_sensor):
     """Verify that humidity sensor works."""
     sensor = await deconz_sensor(
         {
@@ -26,7 +26,7 @@ async def test_humidity_sensor(deconz_sensor):
             "state": {"humidity": 3555, "lastupdated": "2019-05-05T14:39:00"},
             "swversion": "20161129",
             "type": "ZHAHumidity",
-            "uniqueid": "00:15:8d:00:02:45:dc:53-01-0405",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0405",
         },
     )
 
@@ -53,4 +53,4 @@ async def test_humidity_sensor(deconz_sensor):
     assert sensor.name == "Mi temperature 1"
     assert sensor.software_version == "20161129"
     assert sensor.type == "ZHAHumidity"
-    assert sensor.unique_id == "00:15:8d:00:02:45:dc:53-01-0405"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0405"

--- a/tests/sensors/test_light_level.py
+++ b/tests/sensors/test_light_level.py
@@ -3,6 +3,35 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.light_level tests/sensors/test_light_level.py
 """
 
+DATA = {
+    "config": {
+        "alert": "none",
+        "battery": 100,
+        "ledindication": False,
+        "on": True,
+        "pending": [],
+        "reachable": True,
+        "tholddark": 12000,
+        "tholdoffset": 7000,
+        "usertest": False,
+    },
+    "ep": 2,
+    "etag": "5cfb81765e86aa53ace427cfd52c6d52",
+    "manufacturername": "Philips",
+    "modelid": "SML001",
+    "name": "Motion sensor 4",
+    "state": {
+        "dark": True,
+        "daylight": False,
+        "lastupdated": "2019-05-05T14:37:06",
+        "lightlevel": 6955,
+        "lux": 5,
+    },
+    "swversion": "6.1.0.18912",
+    "type": "ZHALightLevel",
+    "uniqueid": "00:17:88:01:03:28:8c:9b-02-0400",
+}
+
 
 async def test_handler_light_level(
     mock_aioresponse, deconz_session, deconz_called_with
@@ -37,36 +66,7 @@ async def test_handler_light_level(
 
 async def test_sensor_light_level(deconz_sensor):
     """Verify that light level sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "alert": "none",
-                "battery": 100,
-                "ledindication": False,
-                "on": True,
-                "pending": [],
-                "reachable": True,
-                "tholddark": 12000,
-                "tholdoffset": 7000,
-                "usertest": False,
-            },
-            "ep": 2,
-            "etag": "5cfb81765e86aa53ace427cfd52c6d52",
-            "manufacturername": "Philips",
-            "modelid": "SML001",
-            "name": "Motion sensor 4",
-            "state": {
-                "dark": True,
-                "daylight": False,
-                "lastupdated": "2019-05-05T14:37:06",
-                "lightlevel": 6955,
-                "lux": 5,
-            },
-            "swversion": "6.1.0.18912",
-            "type": "ZHALightLevel",
-            "uniqueid": "00:17:88:01:03:28:8c:9b-02-0400",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHALightLevel", "CLIPLightLevel")
 

--- a/tests/sensors/test_light_level.py
+++ b/tests/sensors/test_light_level.py
@@ -4,7 +4,7 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 """
 
 
-async def test_configure_lightlevel_sensor(
+async def test_handler_light_level(
     mock_aioresponse, deconz_session, deconz_called_with
 ):
     """Verify that configuring light level sensors works."""
@@ -35,7 +35,7 @@ async def test_configure_lightlevel_sensor(
     )
 
 
-async def test_lightlevel_sensor(deconz_sensor):
+async def test_sensor_light_level(deconz_sensor):
     """Verify that light level sensor works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_open_close.py
+++ b/tests/sensors/test_open_close.py
@@ -1,0 +1,50 @@
+"""Test pydeCONZ open close sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.open_close tests/sensors/test_open_close.py
+"""
+
+
+async def test_sensor_open_close(deconz_sensor):
+    """Verify that open/close sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {
+                "battery": 95,
+                "on": True,
+                "reachable": True,
+                "temperature": 3300,
+            },
+            "ep": 1,
+            "etag": "66cc641d0368110da6882b50090174ac",
+            "manufacturername": "LUMI",
+            "modelid": "lumi.sensor_magnet.aq2",
+            "name": "Back Door",
+            "state": {"lastupdated": "2019-05-05T14:54:32", "open": False},
+            "swversion": "20161128",
+            "type": "ZHAOpenClose",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0006",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAOpenClose", "CLIPOpenClose")
+
+    assert sensor.open is False
+
+    # DeconzSensor
+    assert sensor.battery == 95
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature == 33
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "66cc641d0368110da6882b50090174ac"
+    assert sensor.manufacturer == "LUMI"
+    assert sensor.model_id == "lumi.sensor_magnet.aq2"
+    assert sensor.name == "Back Door"
+    assert sensor.software_version == "20161128"
+    assert sensor.type == "ZHAOpenClose"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0006"

--- a/tests/sensors/test_open_close.py
+++ b/tests/sensors/test_open_close.py
@@ -3,28 +3,28 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.open_close tests/sensors/test_open_close.py
 """
 
+DATA = {
+    "config": {
+        "battery": 95,
+        "on": True,
+        "reachable": True,
+        "temperature": 3300,
+    },
+    "ep": 1,
+    "etag": "66cc641d0368110da6882b50090174ac",
+    "manufacturername": "LUMI",
+    "modelid": "lumi.sensor_magnet.aq2",
+    "name": "Back Door",
+    "state": {"lastupdated": "2019-05-05T14:54:32", "open": False},
+    "swversion": "20161128",
+    "type": "ZHAOpenClose",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0006",
+}
+
 
 async def test_sensor_open_close(deconz_sensor):
     """Verify that open/close sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 95,
-                "on": True,
-                "reachable": True,
-                "temperature": 3300,
-            },
-            "ep": 1,
-            "etag": "66cc641d0368110da6882b50090174ac",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.sensor_magnet.aq2",
-            "name": "Back Door",
-            "state": {"lastupdated": "2019-05-05T14:54:32", "open": False},
-            "swversion": "20161128",
-            "type": "ZHAOpenClose",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0006",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAOpenClose", "CLIPOpenClose")
 

--- a/tests/sensors/test_power.py
+++ b/tests/sensors/test_power.py
@@ -1,0 +1,95 @@
+"""Test pydeCONZ power sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.power tests/sensors/test_power.py
+"""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (
+            {
+                "config": {"on": True, "reachable": True},
+                "ep": 1,
+                "etag": "96e71c7db4685b334d3d0decc3f11868",
+                "manufacturername": "Heiman",
+                "modelid": "SmartPlug",
+                "name": "Power 16",
+                "state": {
+                    "current": 34,
+                    "lastupdated": "2018-03-12T19:22:13",
+                    "power": 64,
+                    "voltage": 231,
+                },
+                "type": "ZHAPower",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0b04",
+            },
+            {
+                "ZHATYPE": ("ZHAPower",),
+                "battery": None,
+                "current": 34,
+                "deconz_id": "/sensors/0",
+                "ep": 1,
+                "etag": "96e71c7db4685b334d3d0decc3f11868",
+                "low_battery": None,
+                "manufacturer": "Heiman",
+                "model_id": "SmartPlug",
+                "name": "Power 16",
+                "on": True,
+                "power": 64,
+                "reachable": True,
+                "resource_type": "sensors",
+                "secondary_temperature": None,
+                "software_version": "",
+                "tampered": None,
+                "type": "ZHAPower",
+                "unique_id": "xx:xx:xx:xx:xx:xx:xx:xx-01-0b04",
+                "voltage": 231,
+            },
+        ),
+        (
+            {
+                "config": {"on": True, "reachable": True, "temperature": 3400},
+                "ep": 2,
+                "etag": "77ab6ddae6dd81469080ad62118d81b6",
+                "lastseen": "2021-07-07T19:30Z",
+                "manufacturername": "LUMI",
+                "modelid": "lumi.plug.maus01",
+                "name": "Power 27",
+                "state": {"lastupdated": "2021-07-07T19:24:59.664", "power": 1},
+                "swversion": "05-02-2018",
+                "type": "ZHAPower",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-000c",
+            },
+            {
+                "ZHATYPE": ("ZHAPower",),
+                "battery": None,
+                "current": None,
+                "deconz_id": "/sensors/0",
+                "ep": 2,
+                "etag": "77ab6ddae6dd81469080ad62118d81b6",
+                "low_battery": None,
+                "manufacturer": "LUMI",
+                "model_id": "lumi.plug.maus01",
+                "name": "Power 27",
+                "on": True,
+                "power": 1,
+                "reachable": True,
+                "secondary_temperature": 34.0,
+                "software_version": "05-02-2018",
+                "tampered": None,
+                "type": "ZHAPower",
+                "unique_id": "xx:xx:xx:xx:xx:xx:xx:xx-02-000c",
+                "voltage": None,
+            },
+        ),
+    ],
+)
+async def test_sensor_power(input, expected, deconz_sensor):
+    """Verify that power sensor works."""
+    sensor = await deconz_sensor(input)
+
+    for attr, value in expected.items():
+        assert getattr(sensor, attr) == value

--- a/tests/sensors/test_power.py
+++ b/tests/sensors/test_power.py
@@ -6,26 +6,53 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 import pytest
 
 
+DATA = {
+    "config": {
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "96e71c7db4685b334d3d0decc3f11868",
+    "manufacturername": "Heiman",
+    "modelid": "SmartPlug",
+    "name": "Power 16",
+    "state": {
+        "current": 34,
+        "lastupdated": "2018-03-12T19:22:13",
+        "power": 64,
+        "voltage": 231,
+    },
+    "type": "ZHAPower",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0b04",
+}
+
+DATA_ONLY_POWER = {
+    "config": {
+        "on": True,
+        "reachable": True,
+        "temperature": 3400,
+    },
+    "ep": 2,
+    "etag": "77ab6ddae6dd81469080ad62118d81b6",
+    "lastseen": "2021-07-07T19:30Z",
+    "manufacturername": "LUMI",
+    "modelid": "lumi.plug.maus01",
+    "name": "Power 27",
+    "state": {
+        "lastupdated": "2021-07-07T19:24:59.664",
+        "power": 1,
+    },
+    "swversion": "05-02-2018",
+    "type": "ZHAPower",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-000c",
+}
+
+
 @pytest.mark.parametrize(
     "input, expected",
     [
         (
-            {
-                "config": {"on": True, "reachable": True},
-                "ep": 1,
-                "etag": "96e71c7db4685b334d3d0decc3f11868",
-                "manufacturername": "Heiman",
-                "modelid": "SmartPlug",
-                "name": "Power 16",
-                "state": {
-                    "current": 34,
-                    "lastupdated": "2018-03-12T19:22:13",
-                    "power": 64,
-                    "voltage": 231,
-                },
-                "type": "ZHAPower",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0b04",
-            },
+            DATA,
             {
                 "ZHATYPE": ("ZHAPower",),
                 "battery": None,
@@ -50,19 +77,7 @@ import pytest
             },
         ),
         (
-            {
-                "config": {"on": True, "reachable": True, "temperature": 3400},
-                "ep": 2,
-                "etag": "77ab6ddae6dd81469080ad62118d81b6",
-                "lastseen": "2021-07-07T19:30Z",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.plug.maus01",
-                "name": "Power 27",
-                "state": {"lastupdated": "2021-07-07T19:24:59.664", "power": 1},
-                "swversion": "05-02-2018",
-                "type": "ZHAPower",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-000c",
-            },
+            DATA_ONLY_POWER,
             {
                 "ZHATYPE": ("ZHAPower",),
                 "battery": None,

--- a/tests/sensors/test_presence.py
+++ b/tests/sensors/test_presence.py
@@ -9,6 +9,57 @@ from pydeconz.models.sensor.presence import (
     PresenceStatePresenceEvent,
 )
 
+DATA = {
+    "config": {
+        "alert": "none",
+        "battery": 100,
+        "delay": 0,
+        "ledindication": False,
+        "on": True,
+        "pending": [],
+        "reachable": True,
+        "sensitivity": 1,
+        "sensitivitymax": 2,
+        "usertest": False,
+    },
+    "ep": 2,
+    "etag": "5cfb81765e86aa53ace427cfd52c6d52",
+    "manufacturername": "Philips",
+    "modelid": "SML001",
+    "name": "Motion sensor 4",
+    "state": {
+        "lastupdated": "2019-05-05T14:37:06",
+        "presence": False,
+    },
+    "swversion": "6.1.0.18912",
+    "type": "ZHAPresence",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-0406",
+}
+
+DATA_PRESENCE_EVENT = {
+    "config": {
+        "devicemode": "undirected",
+        "on": True,
+        "reachable": True,
+        "sensitivity": 3,
+        "triggerdistance": "medium",
+    },
+    "etag": "13ff209f9401b317987d42506dd4cd79",
+    "lastannounced": None,
+    "lastseen": "2022-06-28T23:13Z",
+    "manufacturername": "aqara",
+    "modelid": "lumi.motion.ac01",
+    "name": "Aqara FP1",
+    "state": {
+        "lastupdated": "2022-06-28T23:13:38.577",
+        "presence": True,
+        "presenceevent": "leave",
+    },
+    "swversion": "20210121",
+    "type": "ZHAPresence",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
+}
+
 
 async def test_handler_presence(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that configuring presence sensor works."""
@@ -73,31 +124,7 @@ async def test_handler_presence(mock_aioresponse, deconz_session, deconz_called_
 
 async def test_sensor_presence(mock_aioresponse, deconz_sensor, deconz_called_with):
     """Verify that presence sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "alert": "none",
-                "battery": 100,
-                "delay": 0,
-                "ledindication": False,
-                "on": True,
-                "pending": [],
-                "reachable": True,
-                "sensitivity": 1,
-                "sensitivitymax": 2,
-                "usertest": False,
-            },
-            "ep": 2,
-            "etag": "5cfb81765e86aa53ace427cfd52c6d52",
-            "manufacturername": "Philips",
-            "modelid": "SML001",
-            "name": "Motion sensor 4",
-            "state": {"lastupdated": "2019-05-05T14:37:06", "presence": False},
-            "swversion": "6.1.0.18912",
-            "type": "ZHAPresence",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-0406",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAPresence", "CLIPPresence")
 
@@ -165,31 +192,7 @@ async def test_sensor_presence(mock_aioresponse, deconz_sensor, deconz_called_wi
 
 async def test_presence_event_sensor(deconz_sensor):
     """Verify that presence event sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "devicemode": "undirected",
-                "on": True,
-                "reachable": True,
-                "sensitivity": 3,
-                "triggerdistance": "medium",
-            },
-            "etag": "13ff209f9401b317987d42506dd4cd79",
-            "lastannounced": None,
-            "lastseen": "2022-06-28T23:13Z",
-            "manufacturername": "aqara",
-            "modelid": "lumi.motion.ac01",
-            "name": "Aqara FP1",
-            "state": {
-                "lastupdated": "2022-06-28T23:13:38.577",
-                "presence": True,
-                "presenceevent": "leave",
-            },
-            "swversion": "20210121",
-            "type": "ZHAPresence",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
-        },
-    )
+    sensor = await deconz_sensor(DATA_PRESENCE_EVENT)
 
     assert sensor.ZHATYPE == ("ZHAPresence", "CLIPPresence")
 

--- a/tests/sensors/test_presence.py
+++ b/tests/sensors/test_presence.py
@@ -10,9 +10,7 @@ from pydeconz.models.sensor.presence import (
 )
 
 
-async def test_configure_presence_sensor(
-    mock_aioresponse, deconz_session, deconz_called_with
-):
+async def test_handler_presence(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that configuring presence sensor works."""
     presence = deconz_session.sensors.presence
 
@@ -73,7 +71,7 @@ async def test_configure_presence_sensor(
     )
 
 
-async def test_presence_sensor(mock_aioresponse, deconz_sensor, deconz_called_with):
+async def test_sensor_presence(mock_aioresponse, deconz_sensor, deconz_called_with):
     """Verify that presence sensor works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_pressure.py
+++ b/tests/sensors/test_pressure.py
@@ -1,0 +1,45 @@
+"""Test pydeCONZ pressure sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.pressure tests/sensors/test_pressure.py
+"""
+
+
+async def test_sensor_pressure(deconz_sensor):
+    """Verify that pressure sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"battery": 100, "on": True, "reachable": True},
+            "ep": 1,
+            "etag": "1220e5d026493b6e86207993703a8a71",
+            "manufacturername": "LUMI",
+            "modelid": "lumi.weather",
+            "name": "Mi temperature 1",
+            "state": {"lastupdated": "2019-05-05T14:39:00", "pressure": 1010},
+            "swversion": "20161129",
+            "type": "ZHAPressure",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0403",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAPressure", "CLIPPressure")
+
+    assert sensor.pressure == 1010
+
+    # DeconzSensor
+    assert sensor.battery == 100
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "1220e5d026493b6e86207993703a8a71"
+    assert sensor.manufacturer == "LUMI"
+    assert sensor.model_id == "lumi.weather"
+    assert sensor.name == "Mi temperature 1"
+    assert sensor.software_version == "20161129"
+    assert sensor.type == "ZHAPressure"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0403"

--- a/tests/sensors/test_pressure.py
+++ b/tests/sensors/test_pressure.py
@@ -3,23 +3,30 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.pressure tests/sensors/test_pressure.py
 """
 
+DATA = {
+    "config": {
+        "battery": 100,
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "1220e5d026493b6e86207993703a8a71",
+    "manufacturername": "LUMI",
+    "modelid": "lumi.weather",
+    "name": "Mi temperature 1",
+    "state": {
+        "lastupdated": "2019-05-05T14:39:00",
+        "pressure": 1010,
+    },
+    "swversion": "20161129",
+    "type": "ZHAPressure",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0403",
+}
+
 
 async def test_sensor_pressure(deconz_sensor):
     """Verify that pressure sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"battery": 100, "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "1220e5d026493b6e86207993703a8a71",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.weather",
-            "name": "Mi temperature 1",
-            "state": {"lastupdated": "2019-05-05T14:39:00", "pressure": 1010},
-            "swversion": "20161129",
-            "type": "ZHAPressure",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0403",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAPressure", "CLIPPressure")
 

--- a/tests/sensors/test_relative_rotary.py
+++ b/tests/sensors/test_relative_rotary.py
@@ -5,29 +5,33 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 
 from pydeconz.models.sensor.relative_rotary import RelativeRotaryEvent
 
+DATA = {
+    "config": {
+        "battery": 100,
+        "on": True,
+        "reachable": True,
+    },
+    "etag": "463728970bdb7d04048fc4373654f45a",
+    "lastannounced": "2022-07-03T13:57:59Z",
+    "lastseen": "2022-07-03T14:02Z",
+    "manufacturername": "Signify Netherlands B.V.",
+    "modelid": "RDM002",
+    "name": "RDM002 44",
+    "state": {
+        "expectedeventduration": 400,
+        "expectedrotation": 75,
+        "lastupdated": "2022-07-03T11:37:49.586",
+        "rotaryevent": 2,
+    },
+    "swversion": "2.59.19",
+    "type": "ZHARelativeRotary",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-14-fc00",
+}
+
 
 async def test_sensor_relative_rotary(deconz_sensor):
     """Verify that relative rotary sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"battery": 100, "on": True, "reachable": True},
-            "etag": "463728970bdb7d04048fc4373654f45a",
-            "lastannounced": "2022-07-03T13:57:59Z",
-            "lastseen": "2022-07-03T14:02Z",
-            "manufacturername": "Signify Netherlands B.V.",
-            "modelid": "RDM002",
-            "name": "RDM002 44",
-            "state": {
-                "expectedeventduration": 400,
-                "expectedrotation": 75,
-                "lastupdated": "2022-07-03T11:37:49.586",
-                "rotaryevent": 2,
-            },
-            "swversion": "2.59.19",
-            "type": "ZHARelativeRotary",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-14-fc00",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHARelativeRotary",)
 

--- a/tests/sensors/test_relative_rotary.py
+++ b/tests/sensors/test_relative_rotary.py
@@ -6,7 +6,7 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 from pydeconz.models.sensor.relative_rotary import RelativeRotaryEvent
 
 
-async def test_relative_rotary_sensor(deconz_sensor):
+async def test_sensor_relative_rotary(deconz_sensor):
     """Verify that relative rotary sensor works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_switch.py
+++ b/tests/sensors/test_switch.py
@@ -9,6 +9,121 @@ from pydeconz.models.sensor.switch import (
     SwitchWindowCoveringType,
 )
 
+DATA = {
+    "config": {
+        "battery": 90,
+        "group": "201",
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 2,
+    "etag": "233ae541bbb7ac98c42977753884b8d2",
+    "manufacturername": "Philips",
+    "mode": 1,
+    "modelid": "RWL021",
+    "name": "Dimmer switch 3",
+    "state": {
+        "buttonevent": 1002,
+        "lastupdated": "2019-04-28T20:29:13",
+    },
+    "swversion": "5.45.1.17846",
+    "type": "ZHASwitch",
+    "uniqueid": "00:17:88:01:02:0e:32:a3-02-fc00",
+}
+
+DATA_CUBE = {
+    "config": {
+        "battery": 90,
+        "on": True,
+        "reachable": True,
+        "temperature": 1100,
+    },
+    "ep": 3,
+    "etag": "e34fa1c7a19d960e35a1f4d56ac475af",
+    "manufacturername": "LUMI",
+    "mode": 1,
+    "modelid": "lumi.sensor_cube.aqgl01",
+    "name": "Mi Magic Cube",
+    "state": {
+        "buttonevent": 747,
+        "gesture": 7,
+        "lastupdated": "2019-12-12T18:50:40",
+    },
+    "swversion": "20160704",
+    "type": "ZHASwitch",
+    "uniqueid": "00:15:8d:00:02:8b:3b:24-03-000c",
+}
+DATA_HUE_WALL_SWITCH = {
+    "config": {
+        "battery": 100,
+        "devicemode": "dualrocker",
+        "on": True,
+        "pending": [],
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "01173dc5b19bb0a976006eee8d0d3718",
+    "lastseen": "2021-03-12T22:55Z",
+    "manufacturername": "Signify Netherlands B.V.",
+    "mode": 1,
+    "modelid": "RDM001",
+    "name": "RDM001 15",
+    "state": {
+        "buttonevent": 1002,
+        "eventduration": 1,
+        "lastupdated": "2021-03-12T22:21:20.017",
+    },
+    "swversion": "20210115",
+    "type": "ZHASwitch",
+    "uniqueid": "00:17:88:01:0b:00:05:5d-01-fc00",
+}
+
+DATA_TINT_REMOTE = {
+    "config": {
+        "group": "16388,16389,16390",
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "b1336f750d31300afa441a04f2c69b68",
+    "manufacturername": "MLI",
+    "mode": 1,
+    "modelid": "ZBT-Remote-ALL-RGBW",
+    "name": "ZHA Remote 1",
+    "state": {
+        "angle": 10,
+        "buttonevent": 6002,
+        "lastupdated": "2020-09-08T18:58:24.193",
+        "xy": [0.3381, 0.1627],
+    },
+    "swversion": "2.0",
+    "type": "ZHASwitch",
+    "uniqueid": "00:11:22:33:44:55:66:77-01-1000",
+}
+
+DATA_UBISYS_J1 = {
+    "config": {
+        "mode": "momentary",
+        "on": True,
+        "reachable": False,
+        "windowcoveringtype": 0,
+    },
+    "ep": 2,
+    "etag": "da5fbb89eca4133b6949537e73b31f77",
+    "lastseen": "2020-11-21T15:47Z",
+    "manufacturername": "ubisys",
+    "mode": 1,
+    "modelid": "J1 (5502)",
+    "name": "J1",
+    "state": {
+        "buttonevent": None,
+        "lastupdated": "none",
+    },
+    "swversion": "20190129-DE-FB0",
+    "type": "ZHASwitch",
+    "uniqueid": "00:1f:ee:00:00:00:00:09-02-0102",
+}
+
 
 async def test_handler_switch(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that configuring presence sensor works."""
@@ -41,26 +156,7 @@ async def test_handler_switch(mock_aioresponse, deconz_session, deconz_called_wi
 
 async def test_sensor_switch(deconz_sensor):
     """Verify that switch sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 90,
-                "group": "201",
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 2,
-            "etag": "233ae541bbb7ac98c42977753884b8d2",
-            "manufacturername": "Philips",
-            "mode": 1,
-            "modelid": "RWL021",
-            "name": "Dimmer switch 3",
-            "state": {"buttonevent": 1002, "lastupdated": "2019-04-28T20:29:13"},
-            "swversion": "5.45.1.17846",
-            "type": "ZHASwitch",
-            "uniqueid": "00:17:88:01:02:0e:32:a3-02-fc00",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHASwitch", "ZGPSwitch", "CLIPSwitch")
 
@@ -92,30 +188,7 @@ async def test_sensor_switch(deconz_sensor):
 
 async def test_sensor_switch_sensor_cube(deconz_sensor):
     """Verify that cube switch sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 90,
-                "on": True,
-                "reachable": True,
-                "temperature": 1100,
-            },
-            "ep": 3,
-            "etag": "e34fa1c7a19d960e35a1f4d56ac475af",
-            "manufacturername": "LUMI",
-            "mode": 1,
-            "modelid": "lumi.sensor_cube.aqgl01",
-            "name": "Mi Magic Cube",
-            "state": {
-                "buttonevent": 747,
-                "gesture": 7,
-                "lastupdated": "2019-12-12T18:50:40",
-            },
-            "swversion": "20160704",
-            "type": "ZHASwitch",
-            "uniqueid": "00:15:8d:00:02:8b:3b:24-03-000c",
-        },
-    )
+    sensor = await deconz_sensor(DATA_CUBE)
 
     assert sensor.ZHATYPE == ("ZHASwitch", "ZGPSwitch", "CLIPSwitch")
 
@@ -144,32 +217,7 @@ async def test_sensor_switch_sensor_cube(deconz_sensor):
 
 async def test_sensor_switch_hue_wall_switch_module(deconz_sensor):
     """Verify that cube switch sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "devicemode": "dualrocker",
-                "on": True,
-                "pending": [],
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "01173dc5b19bb0a976006eee8d0d3718",
-            "lastseen": "2021-03-12T22:55Z",
-            "manufacturername": "Signify Netherlands B.V.",
-            "mode": 1,
-            "modelid": "RDM001",
-            "name": "RDM001 15",
-            "state": {
-                "buttonevent": 1002,
-                "eventduration": 1,
-                "lastupdated": "2021-03-12T22:21:20.017",
-            },
-            "swversion": "20210115",
-            "type": "ZHASwitch",
-            "uniqueid": "00:17:88:01:0b:00:05:5d-01-fc00",
-        },
-    )
+    sensor = await deconz_sensor(DATA_HUE_WALL_SWITCH)
 
     assert sensor.ZHATYPE == ("ZHASwitch", "ZGPSwitch", "CLIPSwitch")
 
@@ -204,26 +252,7 @@ async def test_sensor_switch_hue_wall_switch_module(deconz_sensor):
 
 async def test_sensor_switch_tint_remote(deconz_sensor):
     """Verify that tint remote sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"group": "16388,16389,16390", "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "b1336f750d31300afa441a04f2c69b68",
-            "manufacturername": "MLI",
-            "mode": 1,
-            "modelid": "ZBT-Remote-ALL-RGBW",
-            "name": "ZHA Remote 1",
-            "state": {
-                "angle": 10,
-                "buttonevent": 6002,
-                "lastupdated": "2020-09-08T18:58:24.193",
-                "xy": [0.3381, 0.1627],
-            },
-            "swversion": "2.0",
-            "type": "ZHASwitch",
-            "uniqueid": "00:11:22:33:44:55:66:77-01-1000",
-        },
-    )
+    sensor = await deconz_sensor(DATA_TINT_REMOTE)
 
     assert sensor.ZHATYPE == ("ZHASwitch", "ZGPSwitch", "CLIPSwitch")
 
@@ -251,27 +280,7 @@ async def test_sensor_switch_tint_remote(deconz_sensor):
 
 async def test_sensor_switch_ubisys_j1(deconz_sensor):
     """Verify that tint remote sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "mode": "momentary",
-                "on": True,
-                "reachable": False,
-                "windowcoveringtype": 0,
-            },
-            "ep": 2,
-            "etag": "da5fbb89eca4133b6949537e73b31f77",
-            "lastseen": "2020-11-21T15:47Z",
-            "manufacturername": "ubisys",
-            "mode": 1,
-            "modelid": "J1 (5502)",
-            "name": "J1",
-            "state": {"buttonevent": None, "lastupdated": "none"},
-            "swversion": "20190129-DE-FB0",
-            "type": "ZHASwitch",
-            "uniqueid": "00:1f:ee:00:00:00:00:09-02-0102",
-        },
-    )
+    sensor = await deconz_sensor(DATA_UBISYS_J1)
 
     assert sensor.ZHATYPE == ("ZHASwitch", "ZGPSwitch", "CLIPSwitch")
 

--- a/tests/sensors/test_switch.py
+++ b/tests/sensors/test_switch.py
@@ -10,9 +10,7 @@ from pydeconz.models.sensor.switch import (
 )
 
 
-async def test_configure_switch_sensor(
-    mock_aioresponse, deconz_session, deconz_called_with
-):
+async def test_handler_switch(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that configuring presence sensor works."""
     switch = deconz_session.sensors.switch
 
@@ -41,7 +39,7 @@ async def test_configure_switch_sensor(
     )
 
 
-async def test_switch_sensor(deconz_sensor):
+async def test_sensor_switch(deconz_sensor):
     """Verify that switch sensor works."""
     sensor = await deconz_sensor(
         {
@@ -92,7 +90,7 @@ async def test_switch_sensor(deconz_sensor):
     assert sensor.unique_id == "00:17:88:01:02:0e:32:a3-02-fc00"
 
 
-async def test_switch_sensor_cube(deconz_sensor):
+async def test_sensor_switch_sensor_cube(deconz_sensor):
     """Verify that cube switch sensor works."""
     sensor = await deconz_sensor(
         {
@@ -144,7 +142,7 @@ async def test_switch_sensor_cube(deconz_sensor):
     assert sensor.unique_id == "00:15:8d:00:02:8b:3b:24-03-000c"
 
 
-async def test_switch_sensor_hue_wall_switch_module(deconz_sensor):
+async def test_sensor_switch_hue_wall_switch_module(deconz_sensor):
     """Verify that cube switch sensor works."""
     sensor = await deconz_sensor(
         {
@@ -204,7 +202,7 @@ async def test_switch_sensor_hue_wall_switch_module(deconz_sensor):
     assert sensor.unique_id == "00:17:88:01:0b:00:05:5d-01-fc00"
 
 
-async def test_switch_sensor_tint_remote(deconz_sensor):
+async def test_sensor_switch_tint_remote(deconz_sensor):
     """Verify that tint remote sensor works."""
     sensor = await deconz_sensor(
         {
@@ -251,7 +249,7 @@ async def test_switch_sensor_tint_remote(deconz_sensor):
     assert sensor.unique_id == "00:11:22:33:44:55:66:77-01-1000"
 
 
-async def test_switch_ubisys_j1(deconz_sensor):
+async def test_sensor_switch_ubisys_j1(deconz_sensor):
     """Verify that tint remote sensor works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_temperature.py
+++ b/tests/sensors/test_temperature.py
@@ -1,0 +1,46 @@
+"""Test pydeCONZ temperature sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.temperature tests/sensors/test_temperature.py
+"""
+
+
+async def test_sensor_temperature(deconz_sensor):
+    """Verify that temperature sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"battery": 100, "offset": 0, "on": True, "reachable": True},
+            "ep": 1,
+            "etag": "1220e5d026493b6e86207993703a8a71",
+            "manufacturername": "LUMI",
+            "modelid": "lumi.weather",
+            "name": "Mi temperature 1",
+            "state": {"lastupdated": "2019-05-05T14:39:00", "temperature": 2182},
+            "swversion": "20161129",
+            "type": "ZHATemperature",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0402",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHATemperature", "CLIPTemperature")
+
+    assert sensor.temperature == 2182
+    assert sensor.scaled_temperature == 21.8
+
+    # DeconzSensor
+    assert sensor.battery == 100
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "1220e5d026493b6e86207993703a8a71"
+    assert sensor.manufacturer == "LUMI"
+    assert sensor.model_id == "lumi.weather"
+    assert sensor.name == "Mi temperature 1"
+    assert sensor.software_version == "20161129"
+    assert sensor.type == "ZHATemperature"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0402"

--- a/tests/sensors/test_temperature.py
+++ b/tests/sensors/test_temperature.py
@@ -3,23 +3,31 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.temperature tests/sensors/test_temperature.py
 """
 
+DATA = {
+    "config": {
+        "battery": 100,
+        "offset": 0,
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "1220e5d026493b6e86207993703a8a71",
+    "manufacturername": "LUMI",
+    "modelid": "lumi.weather",
+    "name": "Mi temperature 1",
+    "state": {
+        "lastupdated": "2019-05-05T14:39:00",
+        "temperature": 2182,
+    },
+    "swversion": "20161129",
+    "type": "ZHATemperature",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0402",
+}
+
 
 async def test_sensor_temperature(deconz_sensor):
     """Verify that temperature sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"battery": 100, "offset": 0, "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "1220e5d026493b6e86207993703a8a71",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.weather",
-            "name": "Mi temperature 1",
-            "state": {"lastupdated": "2019-05-05T14:39:00", "temperature": 2182},
-            "swversion": "20161129",
-            "type": "ZHATemperature",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0402",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHATemperature", "CLIPTemperature")
 

--- a/tests/sensors/test_thermostat.py
+++ b/tests/sensors/test_thermostat.py
@@ -15,6 +15,94 @@ from pydeconz.models.sensor.thermostat import (
 )
 
 
+DATA = {
+    "config": {
+        "battery": 59,
+        "displayflipped": None,
+        "heatsetpoint": 2100,
+        "locked": None,
+        "mountingmode": None,
+        "offset": 0,
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "6130553ac247174809bae47144ee23f8",
+    "lastseen": "2020-11-29T19:31Z",
+    "manufacturername": "Danfoss",
+    "modelid": "eTRV0100",
+    "name": "Thermostat_stue_sofa",
+    "state": {
+        "errorcode": None,
+        "lastupdated": "2020-11-29T19:28:40.665",
+        "mountingmodeactive": False,
+        "on": True,
+        "temperature": 2102,
+        "valve": 24,
+        "windowopen": "Closed",
+    },
+    "swversion": "01.02.0008 01.02",
+    "type": "ZHAThermostat",
+    "uniqueid": "14:b4:57:ff:fe:d5:4e:77-01-0201",
+}
+
+DATA_EUROTRONIC = {
+    "config": {
+        "battery": 100,
+        "displayflipped": True,
+        "heatsetpoint": 2100,
+        "locked": False,
+        "mode": "auto",
+        "offset": 0,
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "25aac331bc3c4b465cfb2197f6243ea4",
+    "manufacturername": "Eurotronic",
+    "modelid": "SPZB0001",
+    "name": "Living Room Radiator",
+    "state": {
+        "lastupdated": "2019-02-10T22:41:32",
+        "on": False,
+        "temperature": 2149,
+        "valve": 0,
+    },
+    "swversion": "15181120",
+    "type": "ZHAThermostat",
+    "uniqueid": "00:15:8d:00:01:92:d2:51-01-0201",
+}
+DATA_TUYA = {
+    "config": {
+        "battery": 100,
+        "heatsetpoint": 1550,
+        "locked": None,
+        "offset": 0,
+        "on": True,
+        "preset": "auto",
+        "reachable": True,
+        "schedule": {},
+        "schedule_on": None,
+        "setvalve": True,
+        "windowopen_set": True,
+    },
+    "ep": 1,
+    "etag": "36850fc8521f7c23606c9304b2e1f7bb",
+    "lastseen": "2020-11-11T21:23Z",
+    "manufacturername": "_TYST11_kfvq6avy",
+    "modelid": "fvq6avy",
+    "name": "fvq6avy",
+    "state": {
+        "lastupdated": "none",
+        "on": None,
+        "temperature": 2290,
+    },
+    "swversion": "20180727",
+    "type": "ZHAThermostat",
+    "uniqueid": "bc:33:ac:ff:fe:47:a1:95-01-0201",
+}
+
+
 async def test_handler_thermostat(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that configuring thermostat sensor works."""
     thermostat = deconz_session.sensors.thermostat
@@ -70,38 +158,7 @@ async def test_sensor_danfoss_thermostat(deconz_sensor):
 
     Danfoss thermostat is the simplest kind with only control over temperaturdeconz_sensore.
     """
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 59,
-                "displayflipped": None,
-                "heatsetpoint": 2100,
-                "locked": None,
-                "mountingmode": None,
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "6130553ac247174809bae47144ee23f8",
-            "lastseen": "2020-11-29T19:31Z",
-            "manufacturername": "Danfoss",
-            "modelid": "eTRV0100",
-            "name": "Thermostat_stue_sofa",
-            "state": {
-                "errorcode": None,
-                "lastupdated": "2020-11-29T19:28:40.665",
-                "mountingmodeactive": False,
-                "on": True,
-                "temperature": 2102,
-                "valve": 24,
-                "windowopen": "Closed",
-            },
-            "swversion": "01.02.0008 01.02",
-            "type": "ZHAThermostat",
-            "uniqueid": "14:b4:57:ff:fe:d5:4e:77-01-0201",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAThermostat", "CLIPThermostat")
 
@@ -151,34 +208,7 @@ async def test_sensor_danfoss_thermostat(deconz_sensor):
 
 async def test_sensor_eurotronic_thermostat(deconz_sensor):
     """Verify that thermostat sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "displayflipped": True,
-                "heatsetpoint": 2100,
-                "locked": False,
-                "mode": "auto",
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "25aac331bc3c4b465cfb2197f6243ea4",
-            "manufacturername": "Eurotronic",
-            "modelid": "SPZB0001",
-            "name": "Living Room Radiator",
-            "state": {
-                "lastupdated": "2019-02-10T22:41:32",
-                "on": False,
-                "temperature": 2149,
-                "valve": 0,
-            },
-            "swversion": "15181120",
-            "type": "ZHAThermostat",
-            "uniqueid": "00:15:8d:00:01:92:d2:51-01-0201",
-        },
-    )
+    sensor = await deconz_sensor(DATA_EUROTRONIC)
 
     assert sensor.ZHATYPE == ("ZHAThermostat", "CLIPThermostat")
 
@@ -225,33 +255,7 @@ async def test_sensor_eurotronic_thermostat(deconz_sensor):
 
 async def test_sensor_tuya_thermostat(deconz_sensor):
     """Verify that Tuya thermostat works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "heatsetpoint": 1550,
-                "locked": None,
-                "offset": 0,
-                "on": True,
-                "preset": "auto",
-                "reachable": True,
-                "schedule": {},
-                "schedule_on": None,
-                "setvalve": True,
-                "windowopen_set": True,
-            },
-            "ep": 1,
-            "etag": "36850fc8521f7c23606c9304b2e1f7bb",
-            "lastseen": "2020-11-11T21:23Z",
-            "manufacturername": "_TYST11_kfvq6avy",
-            "modelid": "fvq6avy",
-            "name": "fvq6avy",
-            "state": {"lastupdated": "none", "on": None, "temperature": 2290},
-            "swversion": "20180727",
-            "type": "ZHAThermostat",
-            "uniqueid": "bc:33:ac:ff:fe:47:a1:95-01-0201",
-        },
-    )
+    sensor = await deconz_sensor(DATA_TUYA)
 
     assert sensor.ZHATYPE == Thermostat.ZHATYPE
 

--- a/tests/sensors/test_thermostat.py
+++ b/tests/sensors/test_thermostat.py
@@ -15,9 +15,7 @@ from pydeconz.models.sensor.thermostat import (
 )
 
 
-async def test_configure_thermostat(
-    mock_aioresponse, deconz_session, deconz_called_with
-):
+async def test_handler_thermostat(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that configuring thermostat sensor works."""
     thermostat = deconz_session.sensors.thermostat
 
@@ -67,7 +65,7 @@ async def test_configure_thermostat(
     )
 
 
-async def test_danfoss_thermostat(deconz_sensor):
+async def test_sensor_danfoss_thermostat(deconz_sensor):
     """Verify that Danfoss thermostat works.
 
     Danfoss thermostat is the simplest kind with only control over temperaturdeconz_sensore.
@@ -151,7 +149,7 @@ async def test_danfoss_thermostat(deconz_sensor):
     assert sensor.unique_id == "14:b4:57:ff:fe:d5:4e:77-01-0201"
 
 
-async def test_eurotronic_thermostat(deconz_sensor):
+async def test_sensor_eurotronic_thermostat(deconz_sensor):
     """Verify that thermostat sensor works."""
     sensor = await deconz_sensor(
         {
@@ -225,7 +223,7 @@ async def test_eurotronic_thermostat(deconz_sensor):
     assert sensor.unique_id == "00:15:8d:00:01:92:d2:51-01-0201"
 
 
-async def test_tuya_thermostat(mock_aioresponse, deconz_sensor, deconz_called_with):
+async def test_sensor_tuya_thermostat(deconz_sensor):
     """Verify that Tuya thermostat works."""
     sensor = await deconz_sensor(
         {

--- a/tests/sensors/test_time.py
+++ b/tests/sensors/test_time.py
@@ -1,0 +1,51 @@
+"""Test pydeCONZ time sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.time tests/sensors/test_time.py
+"""
+
+
+async def test_sensor_time(deconz_sensor):
+    """Verify that time sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {"battery": 40, "on": True, "reachable": True},
+            "ep": 1,
+            "etag": "28e796678d9a24712feef59294343bb6",
+            "lastseen": "2020-11-22T11:26Z",
+            "manufacturername": "Danfoss",
+            "modelid": "eTRV0100",
+            "name": "eTRV Séjour",
+            "state": {
+                "lastset": "2020-11-19T08:07:08Z",
+                "lastupdated": "2020-11-22T10:51:03.444",
+                "localtime": "2020-11-22T10:51:01",
+                "utc": "2020-11-22T10:51:01Z",
+            },
+            "swversion": "20200429",
+            "type": "ZHATime",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-000a",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHATime",)
+
+    assert sensor.last_set == "2020-11-19T08:07:08Z"
+
+    # DeconzSensor
+    assert sensor.battery == 40
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature is None
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "28e796678d9a24712feef59294343bb6"
+    assert sensor.manufacturer == "Danfoss"
+    assert sensor.model_id == "eTRV0100"
+    assert sensor.name == "eTRV Séjour"
+    assert sensor.software_version == "20200429"
+    assert sensor.type == "ZHATime"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-000a"

--- a/tests/sensors/test_time.py
+++ b/tests/sensors/test_time.py
@@ -3,29 +3,33 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.time tests/sensors/test_time.py
 """
 
+DATA = {
+    "config": {
+        "battery": 40,
+        "on": True,
+        "reachable": True,
+    },
+    "ep": 1,
+    "etag": "28e796678d9a24712feef59294343bb6",
+    "lastseen": "2020-11-22T11:26Z",
+    "manufacturername": "Danfoss",
+    "modelid": "eTRV0100",
+    "name": "eTRV Séjour",
+    "state": {
+        "lastset": "2020-11-19T08:07:08Z",
+        "lastupdated": "2020-11-22T10:51:03.444",
+        "localtime": "2020-11-22T10:51:01",
+        "utc": "2020-11-22T10:51:01Z",
+    },
+    "swversion": "20200429",
+    "type": "ZHATime",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-000a",
+}
+
 
 async def test_sensor_time(deconz_sensor):
     """Verify that time sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"battery": 40, "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "28e796678d9a24712feef59294343bb6",
-            "lastseen": "2020-11-22T11:26Z",
-            "manufacturername": "Danfoss",
-            "modelid": "eTRV0100",
-            "name": "eTRV Séjour",
-            "state": {
-                "lastset": "2020-11-19T08:07:08Z",
-                "lastupdated": "2020-11-22T10:51:03.444",
-                "localtime": "2020-11-22T10:51:01",
-                "utc": "2020-11-22T10:51:01Z",
-            },
-            "swversion": "20200429",
-            "type": "ZHATime",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-000a",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHATime",)
 

--- a/tests/sensors/test_vibration.py
+++ b/tests/sensors/test_vibration.py
@@ -5,37 +5,37 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydecon
 
 from unittest.mock import Mock
 
+DATA = {
+    "config": {
+        "battery": 91,
+        "on": True,
+        "pending": [],
+        "reachable": True,
+        "sensitivity": 21,
+        "sensitivitymax": 21,
+        "temperature": 3200,
+    },
+    "ep": 1,
+    "etag": "b7599df551944df97b2aa87d160b9c45",
+    "manufacturername": "LUMI",
+    "modelid": "lumi.vibration.aq1",
+    "name": "Vibration 1",
+    "state": {
+        "lastupdated": "2019-03-09T15:53:07",
+        "orientation": [10, 1059, 0],
+        "tiltangle": 83,
+        "vibration": True,
+        "vibrationstrength": 114,
+    },
+    "swversion": "20180130",
+    "type": "ZHAVibration",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
+}
+
 
 async def test_sensor_vibration(deconz_sensor):
     """Verify that vibration sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 91,
-                "on": True,
-                "pending": [],
-                "reachable": True,
-                "sensitivity": 21,
-                "sensitivitymax": 21,
-                "temperature": 3200,
-            },
-            "ep": 1,
-            "etag": "b7599df551944df97b2aa87d160b9c45",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.vibration.aq1",
-            "name": "Vibration 1",
-            "state": {
-                "lastupdated": "2019-03-09T15:53:07",
-                "orientation": [10, 1059, 0],
-                "tiltangle": 83,
-                "vibration": True,
-                "vibrationstrength": 114,
-            },
-            "swversion": "20180130",
-            "type": "ZHAVibration",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAVibration",)
 

--- a/tests/sensors/test_vibration.py
+++ b/tests/sensors/test_vibration.py
@@ -1,0 +1,78 @@
+"""Test pydeCONZ vibration sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.vibration tests/sensors/test_vibration.py
+"""
+
+from unittest.mock import Mock
+
+
+async def test_sensor_vibration(deconz_sensor):
+    """Verify that vibration sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {
+                "battery": 91,
+                "on": True,
+                "pending": [],
+                "reachable": True,
+                "sensitivity": 21,
+                "sensitivitymax": 21,
+                "temperature": 3200,
+            },
+            "ep": 1,
+            "etag": "b7599df551944df97b2aa87d160b9c45",
+            "manufacturername": "LUMI",
+            "modelid": "lumi.vibration.aq1",
+            "name": "Vibration 1",
+            "state": {
+                "lastupdated": "2019-03-09T15:53:07",
+                "orientation": [10, 1059, 0],
+                "tiltangle": 83,
+                "vibration": True,
+                "vibrationstrength": 114,
+            },
+            "swversion": "20180130",
+            "type": "ZHAVibration",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAVibration",)
+
+    assert sensor.orientation == [10, 1059, 0]
+    assert sensor.sensitivity == 21
+    assert sensor.max_sensitivity == 21
+    assert sensor.tilt_angle == 83
+    assert sensor.vibration is True
+    assert sensor.vibration_strength == 114
+
+    # DeconzSensor
+    assert sensor.battery == 91
+    assert sensor.ep == 1
+    assert sensor.low_battery is None
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is None
+    assert sensor.secondary_temperature == 32
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "b7599df551944df97b2aa87d160b9c45"
+    assert sensor.manufacturer == "LUMI"
+    assert sensor.model_id == "lumi.vibration.aq1"
+    assert sensor.name == "Vibration 1"
+    assert sensor.software_version == "20180130"
+    assert sensor.type == "ZHAVibration"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0101"
+
+    sensor.register_callback(mock_callback := Mock())
+    assert sensor._callbacks
+
+    event = {"state": {"lastupdated": "2019-03-15T10:15:17", "orientation": [0, 84, 6]}}
+    sensor.update(event)
+
+    mock_callback.assert_called_once()
+    assert sensor.changed_keys == {"state", "lastupdated", "orientation"}
+
+    sensor.remove_callback(mock_callback)
+    assert not sensor._callbacks

--- a/tests/sensors/test_water.py
+++ b/tests/sensors/test_water.py
@@ -3,33 +3,33 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.water tests/sensors/test_water.py
 """
 
+DATA = {
+    "config": {
+        "battery": 100,
+        "on": True,
+        "reachable": True,
+        "temperature": 2500,
+    },
+    "ep": 1,
+    "etag": "fae893708dfe9b358df59107d944fa1c",
+    "manufacturername": "LUMI",
+    "modelid": "lumi.sensor_wleak.aq1",
+    "name": "water2",
+    "state": {
+        "lastupdated": "2019-01-29T07:13:20",
+        "lowbattery": False,
+        "tampered": False,
+        "water": False,
+    },
+    "swversion": "20170721",
+    "type": "ZHAWater",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
+}
+
 
 async def test_sensor_water(deconz_sensor):
     """Verify that water sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "on": True,
-                "reachable": True,
-                "temperature": 2500,
-            },
-            "ep": 1,
-            "etag": "fae893708dfe9b358df59107d944fa1c",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.sensor_wleak.aq1",
-            "name": "water2",
-            "state": {
-                "lastupdated": "2019-01-29T07:13:20",
-                "lowbattery": False,
-                "tampered": False,
-                "water": False,
-            },
-            "swversion": "20170721",
-            "type": "ZHAWater",
-            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
-        },
-    )
+    sensor = await deconz_sensor(DATA)
 
     assert sensor.ZHATYPE == ("ZHAWater",)
 

--- a/tests/sensors/test_water.py
+++ b/tests/sensors/test_water.py
@@ -1,0 +1,55 @@
+"""Test pydeCONZ water sensor.
+
+pytest --cov-report term-missing --cov=pydeconz.interfaces.sensors --cov=pydeconz.models.sensor.water tests/sensors/test_water.py
+"""
+
+
+async def test_sensor_water(deconz_sensor):
+    """Verify that water sensor works."""
+    sensor = await deconz_sensor(
+        {
+            "config": {
+                "battery": 100,
+                "on": True,
+                "reachable": True,
+                "temperature": 2500,
+            },
+            "ep": 1,
+            "etag": "fae893708dfe9b358df59107d944fa1c",
+            "manufacturername": "LUMI",
+            "modelid": "lumi.sensor_wleak.aq1",
+            "name": "water2",
+            "state": {
+                "lastupdated": "2019-01-29T07:13:20",
+                "lowbattery": False,
+                "tampered": False,
+                "water": False,
+            },
+            "swversion": "20170721",
+            "type": "ZHAWater",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
+        },
+    )
+
+    assert sensor.ZHATYPE == ("ZHAWater",)
+
+    assert sensor.water is False
+
+    # DeconzSensor
+    assert sensor.battery == 100
+    assert sensor.ep == 1
+    assert sensor.low_battery is False
+    assert sensor.on is True
+    assert sensor.reachable is True
+    assert sensor.tampered is False
+    assert sensor.secondary_temperature == 25
+
+    # DeconzDevice
+    assert sensor.deconz_id == "/sensors/0"
+    assert sensor.etag == "fae893708dfe9b358df59107d944fa1c"
+    assert sensor.manufacturer == "LUMI"
+    assert sensor.model_id == "lumi.sensor_wleak.aq1"
+    assert sensor.name == "water2"
+    assert sensor.software_version == "20170721"
+    assert sensor.type == "ZHAWater"
+    assert sensor.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01-0500"

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -3,462 +3,64 @@
 pytest --cov-report term-missing --cov=pydeconz.sensor tests/test_sensors.py
 """
 
+from tests import sensors as sensor_test_data
 
-async def test_create_all_sensor_types(deconz_refresh_state):
+
+async def test_create_all_sensors(deconz_refresh_state):
     """Verify that creating all sensors work."""
     deconz_session = await deconz_refresh_state(
         sensors={
-            "0": {
-                "config": {
-                    "battery": 100,
-                    "on": True,
-                    "reachable": True,
-                    "temperature": 2500,
-                },
-                "ep": 1,
-                "etag": "fae893708dfe9b358df59107d944fa1c",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.sensor_wleak.aq1",
-                "name": "water2",
-                "state": {
-                    "lastupdated": "2019-01-29T07:13:20",
-                    "lowbattery": False,
-                    "tampered": False,
-                    "water": False,
-                },
-                "swversion": "20170721",
-                "type": "ZHAWater",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
-            },
-            "1": {
-                "config": {
-                    "battery": 91,
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                    "sensitivity": 21,
-                    "sensitivitymax": 21,
-                    "temperature": 3200,
-                },
-                "ep": 1,
-                "etag": "b7599df551944df97b2aa87d160b9c45",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.vibration.aq1",
-                "name": "Vibration 1",
-                "state": {
-                    "lastupdated": "2019-03-09T15:53:07",
-                    "orientation": [10, 1059, 0],
-                    "tiltangle": 83,
-                    "vibration": True,
-                    "vibrationstrength": 114,
-                },
-                "swversion": "20180130",
-                "type": "ZHAVibration",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
-            },
-            "2": {
-                "config": {"battery": 40, "on": True, "reachable": True},
-                "ep": 1,
-                "etag": "28e796678d9a24712feef59294343bb6",
-                "lastseen": "2020-11-22T11:26Z",
-                "manufacturername": "Danfoss",
-                "modelid": "eTRV0100",
-                "name": "eTRV Séjour",
-                "state": {
-                    "lastset": "2020-11-19T08:07:08Z",
-                    "lastupdated": "2020-11-22T10:51:03.444",
-                    "localtime": "2020-11-22T10:51:01",
-                    "utc": "2020-11-22T10:51:01Z",
-                },
-                "swversion": "20200429",
-                "type": "ZHATime",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-000a",
-            },
-            "3": {
-                "config": {
-                    "battery": 59,
-                    "displayflipped": None,
-                    "heatsetpoint": 2100,
-                    "locked": None,
-                    "mountingmode": None,
-                    "offset": 0,
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "6130553ac247174809bae47144ee23f8",
-                "lastseen": "2020-11-29T19:31Z",
-                "manufacturername": "Danfoss",
-                "modelid": "eTRV0100",
-                "name": "Thermostat_stue_sofa",
-                "state": {
-                    "errorcode": None,
-                    "lastupdated": "2020-11-29T19:28:40.665",
-                    "mountingmodeactive": False,
-                    "on": True,
-                    "temperature": 2102,
-                    "valve": 24,
-                    "windowopen": "Closed",
-                },
-                "swversion": "01.02.0008 01.02",
-                "type": "ZHAThermostat",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0201",
-            },
-            "4": {
-                "config": {"battery": 100, "offset": 0, "on": True, "reachable": True},
-                "ep": 1,
-                "etag": "1220e5d026493b6e86207993703a8a71",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.weather",
-                "name": "Mi temperature 1",
-                "state": {"lastupdated": "2019-05-05T14:39:00", "temperature": 2182},
-                "swversion": "20161129",
-                "type": "ZHATemperature",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0402",
-            },
-            "5": {
-                "config": {
-                    "battery": 100,
-                    "devicemode": "dualrocker",
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "01173dc5b19bb0a976006eee8d0d3718",
-                "lastseen": "2021-03-12T22:55Z",
-                "manufacturername": "Signify Netherlands B.V.",
-                "mode": 1,
-                "modelid": "RDM001",
-                "name": "RDM001 15",
-                "state": {
-                    "buttonevent": 1002,
-                    "eventduration": 1,
-                    "lastupdated": "2021-03-12T22:21:20.017",
-                },
-                "swversion": "20210115",
-                "type": "ZHASwitch",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-fc00",
-            },
-            "6": {
-                "config": {"battery": 100, "on": True, "reachable": True},
-                "ep": 1,
-                "etag": "1220e5d026493b6e86207993703a8a71",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.weather",
-                "name": "Mi temperature 1",
-                "state": {"lastupdated": "2019-05-05T14:39:00", "pressure": 1010},
-                "swversion": "20161129",
-                "type": "ZHAPressure",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0403",
-            },
-            "7": {
-                "config": {
-                    "alert": "none",
-                    "battery": 100,
-                    "delay": 0,
-                    "ledindication": False,
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                    "sensitivity": 1,
-                    "sensitivitymax": 2,
-                    "usertest": False,
-                },
-                "ep": 2,
-                "etag": "5cfb81765e86aa53ace427cfd52c6d52",
-                "manufacturername": "Philips",
-                "modelid": "SML001",
-                "name": "Motion sensor 4",
-                "state": {"lastupdated": "2019-05-05T14:37:06", "presence": False},
-                "swversion": "6.1.0.18912",
-                "type": "ZHAPresence",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-0406",
-            },
-            "8": {
-                "config": {"on": True, "reachable": True},
-                "ep": 1,
-                "etag": "96e71c7db4685b334d3d0decc3f11868",
-                "manufacturername": "Heiman",
-                "modelid": "SmartPlug",
-                "name": "Power 16",
-                "state": {
-                    "current": 34,
-                    "lastupdated": "2018-03-12T19:22:13",
-                    "power": 64,
-                    "voltage": 231,
-                },
-                "type": "ZHAPower",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0b04",
-            },
-            "9": {
-                "config": {
-                    "battery": 95,
-                    "on": True,
-                    "reachable": True,
-                    "temperature": 3300,
-                },
-                "ep": 1,
-                "etag": "66cc641d0368110da6882b50090174ac",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.sensor_magnet.aq2",
-                "name": "Back Door",
-                "state": {"lastupdated": "2019-05-05T14:54:32", "open": False},
-                "swversion": "20161128",
-                "type": "ZHAOpenClose",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0006",
-            },
-            "10": {
-                "config": {
-                    "alert": "none",
-                    "battery": 100,
-                    "ledindication": False,
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                    "tholddark": 12000,
-                    "tholdoffset": 7000,
-                    "usertest": False,
-                },
-                "ep": 2,
-                "etag": "5cfb81765e86aa53ace427cfd52c6d52",
-                "manufacturername": "Philips",
-                "modelid": "SML001",
-                "name": "Motion sensor 4",
-                "state": {
-                    "dark": True,
-                    "daylight": False,
-                    "lastupdated": "2019-05-05T14:37:06",
-                    "lightlevel": 6955,
-                    "lux": 5,
-                },
-                "swversion": "6.1.0.18912",
-                "type": "ZHALightLevel",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-0400",
-            },
-            "11": {
-                "config": {"battery": 100, "offset": 0, "on": True, "reachable": True},
-                "ep": 1,
-                "etag": "1220e5d026493b6e86207993703a8a71",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.weather",
-                "name": "Mi temperature 1",
-                "state": {"humidity": 3555, "lastupdated": "2019-05-05T14:39:00"},
-                "swversion": "20161129",
-                "type": "ZHAHumidity",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0405",
-            },
-            "12": {
-                "config": {"on": True, "reachable": True},
-                "etag": "aacc83bc7d6e4af7e44014e9f776b206",
-                "manufacturername": "Phoscon",
-                "modelid": "PHOSCON_FSM_STATE",
-                "name": "FSM_STATE Motion stair",
-                "state": {"lastupdated": "2019-04-24T00:00:25", "status": 0},
-                "swversion": "1.0",
-                "type": "CLIPGenericStatus",
-                "uniqueid": "fsm-state-1520195376277",
-            },
-            "13": {
-                "config": {"on": True, "reachable": True},
-                "modelid": "Switch",
-                "name": "Kitchen Switch",
-                "state": {"flag": True, "lastupdated": "2018-07-01T10:40:35"},
-                "swversion": "1.0.0",
-                "type": "CLIPGenericFlag",
-                "uniqueid": "kitchen-switch",
-            },
-            "14": {
-                "config": {"on": True, "battery": 90, "reachable": True},
-                "ep": 1,
-                "etag": "abcdef1234567890abcdef1234567890",
-                "manufacturername": "frient A/S",
-                "modelid": "SMSZB-120",
-                "name": "Fire alarm",
-                "state": {
-                    "fire": False,
-                    "lastupdated": "2021-11-25T08:00:02.003",
-                    "lowbattery": False,
-                    "test": True,
-                },
-                "swversion": "20210526 05:57",
-                "type": "ZHAFire",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-88-9900",
-            },
-            "15": {
-                "config": {
-                    "battery": 100,
-                    "lock": False,
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 11,
-                "etag": "a43862f76b7fa48b0fbb9107df123b0e",
-                "lastseen": "2021-03-06T22:25Z",
-                "manufacturername": "Onesti Products AS",
-                "modelid": "easyCodeTouch_v1",
-                "name": "easyCodeTouch_v1",
-                "state": {
-                    "lastupdated": "2021-03-06T21:25:45.624",
-                    "lockstate": "unlocked",
-                },
-                "swversion": "20201211",
-                "type": "ZHADoorLock",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-xx-0101",
-            },
-            "16": {
-                "config": {
-                    "configured": True,
-                    "on": True,
-                    "sunriseoffset": 30,
-                    "sunsetoffset": -30,
-                },
-                "etag": "55047cf652a7e594d0ee7e6fae01dd38",
-                "manufacturername": "Philips",
-                "modelid": "PHDL00",
-                "name": "Daylight",
-                "state": {
-                    "daylight": True,
-                    "lastupdated": "2018-03-24T17:26:12",
-                    "status": 170,
-                },
-                "swversion": "1.0",
-                "type": "Daylight",
-            },
-            "17": {
-                "config": {"on": True, "reachable": True},
-                "ep": 1,
-                "etag": "a99e5bc463d15c23af7e89946e784cca",
-                "manufacturername": "Heiman",
-                "modelid": "SmartPlug",
-                "name": "Consumption 15",
-                "state": {
-                    "consumption": 11342,
-                    "lastupdated": "2018-03-12T19:19:08",
-                    "power": 123,
-                },
-                "type": "ZHAConsumption",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0702",
-            },
-            "18": {
-                "config": {
-                    "battery": 100,
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "b7599df551944df97b2aa87d160b9c45",
-                "manufacturername": "Heiman",
-                "modelid": "CO_V16",
-                "name": "Cave, CO",
-                "state": {
-                    "carbonmonoxide": False,
-                    "lastupdated": "none",
-                    "lowbattery": False,
-                    "tampered": False,
-                },
-                "swversion": "20150330",
-                "type": "ZHACarbonMonoxide",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
-            },
-            "19": {
-                "config": {"alert": "none", "on": True, "reachable": True},
-                "ep": 1,
-                "etag": "23a8659f1cb22df2f51bc2da0e241bb4",
-                "manufacturername": "IKEA of Sweden",
-                "modelid": "FYRTUR block-out roller blind",
-                "name": "FYRTUR block-out roller blind",
-                "state": {"battery": 100, "lastupdated": "none"},
-                "swversion": "2.2.007",
-                "type": "ZHABattery",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0001",
-            },
-            "20": {
-                "config": {
-                    "battery": 95,
-                    "enrolled": 1,
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
-                "lastseen": "2021-07-25T18:07Z",
-                "manufacturername": "lk",
-                "modelid": "ZB-KeypadGeneric-D0002",
-                "name": "Keypad",
-                "state": {
-                    "action": "armed_stay",
-                    "lastupdated": "2021-07-25T18:02:51.172",
-                    "lowbattery": False,
-                    "panel": "exit_delay",
-                    "seconds_remaining": 55,
-                    "tampered": False,
-                },
-                "swversion": "3.13",
-                "type": "ZHAAncillaryControl",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0501",
-            },
-            "21": {
-                "config": {
-                    "battery": 100,
-                    "on": True,
-                    "reachable": True,
-                    "temperature": 2600,
-                },
-                "ep": 1,
-                "etag": "18c0f3c2100904e31a7f938db2ba9ba9",
-                "manufacturername": "dresden elektronik",
-                "modelid": "lumi.sensor_motion.aq2",
-                "name": "Alarm 10",
-                "state": {
-                    "alarm": False,
-                    "lastupdated": "none",
-                    "lowbattery": None,
-                    "tampered": None,
-                },
-                "swversion": "20170627",
-                "type": "ZHAAlarm",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
-            },
-            "22": {
-                "config": {"on": True, "reachable": True},
-                "ep": 2,
-                "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
-                "lastseen": "2020-11-20T22:48Z",
-                "manufacturername": "BOSCH",
-                "modelid": "AIR",
-                "name": "BOSCH Air quality sensor",
-                "state": {
-                    "airquality": "poor",
-                    "airqualityppb": 809,
-                    "lastupdated": "2020-11-20T22:48:00.209",
-                },
-                "swversion": "20200402",
-                "type": "ZHAAirQuality",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-fdef",
-            },
+            "0": sensor_test_data.test_air_purifier.DATA,
+            "1": sensor_test_data.test_air_quality.DATA,
+            "2": sensor_test_data.test_alarm.DATA,
+            "3": sensor_test_data.test_ancillary_control.DATA,
+            "4": sensor_test_data.test_battery.DATA,
+            "5": sensor_test_data.test_carbon_monoxide.DATA,
+            "6": sensor_test_data.test_consumption.DATA,
+            "7": sensor_test_data.test_daylight.DATA,
+            "8": sensor_test_data.test_door_lock.DATA,
+            "9": sensor_test_data.test_fire.DATA,
+            "10": sensor_test_data.test_generic_flag.DATA,
+            "11": sensor_test_data.test_generic_status.DATA,
+            "12": sensor_test_data.test_humidity.DATA,
+            "13": sensor_test_data.test_light_level.DATA,
+            "14": sensor_test_data.test_open_close.DATA,
+            "15": sensor_test_data.test_power.DATA,
+            "16": sensor_test_data.test_presence.DATA,
+            "17": sensor_test_data.test_pressure.DATA,
+            "18": sensor_test_data.test_relative_rotary.DATA,
+            "19": sensor_test_data.test_switch.DATA,
+            "20": sensor_test_data.test_temperature.DATA,
+            "21": sensor_test_data.test_thermostat.DATA,
+            "22": sensor_test_data.test_time.DATA,
+            "23": sensor_test_data.test_vibration.DATA,
+            "24": sensor_test_data.test_water.DATA,
         },
     )
     sensors = deconz_session.sensors
-    assert len(sensors.keys()) == 23
-    assert sensors["0"].type == "ZHAWater"
-    assert sensors["1"].type == "ZHAVibration"
-    assert sensors["2"].type == "ZHATime"
-    assert sensors["3"].type == "ZHAThermostat"
-    assert sensors["4"].type == "ZHATemperature"
-    assert sensors["5"].type == "ZHASwitch"
-    assert sensors["7"].type == "ZHAPresence"
-    assert sensors["8"].type == "ZHAPower"
-    assert sensors["9"].type == "ZHAOpenClose"
-    assert sensors["10"].type == "ZHALightLevel"
-    assert sensors["11"].type == "ZHAHumidity"
-    assert sensors["12"].type == "CLIPGenericStatus"
-    assert sensors["13"].type == "CLIPGenericFlag"
-    assert sensors["14"].type == "ZHAFire"
-    assert sensors["15"].type == "ZHADoorLock"
-    assert sensors["17"].type == "ZHAConsumption"
-    assert sensors["18"].type == "ZHACarbonMonoxide"
-    assert sensors["19"].type == "ZHABattery"
-    assert sensors["22"].type == "ZHAAirQuality"
+    assert len(sensors._handlers) == 25
+    assert sensors["0"].type == "ZHAAirPurifier"
+    assert sensors["1"].type == "ZHAAirQuality"
+    assert sensors["2"].type == "ZHAAlarm"
+    assert sensors["3"].type == "ZHAAncillaryControl"
+    assert sensors["4"].type == "ZHABattery"
+    assert sensors["5"].type == "ZHACarbonMonoxide"
+    assert sensors["6"].type == "ZHAConsumption"
+    assert sensors["7"].type == "Daylight"
+    assert sensors["8"].type == "ZHADoorLock"
+    assert sensors["9"].type == "ZHAFire"
+    assert sensors["10"].type == "CLIPGenericFlag"
+    assert sensors["11"].type == "CLIPGenericStatus"
+    assert sensors["12"].type == "ZHAHumidity"
+    assert sensors["13"].type == "ZHALightLevel"
+    assert sensors["14"].type == "ZHAOpenClose"
+    assert sensors["15"].type == "ZHAPower"
+    assert sensors["16"].type == "ZHAPresence"
+    assert sensors["17"].type == "ZHAPressure"
+    assert sensors["18"].type == "ZHARelativeRotary"
+    assert sensors["19"].type == "ZHASwitch"
+    assert sensors["20"].type == "ZHATemperature"
+    assert sensors["21"].type == "ZHAThermostat"
+    assert sensors["22"].type == "ZHATime"
+    assert sensors["23"].type == "ZHAVibration"
+    assert sensors["24"].type == "ZHAWater"

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -3,839 +3,6 @@
 pytest --cov-report term-missing --cov=pydeconz.sensor tests/test_sensors.py
 """
 
-from unittest.mock import Mock
-
-import pytest
-
-
-@pytest.fixture
-def deconz_sensor(deconz_refresh_state):
-    """Comfort fixture to initialize deCONZ sensor."""
-
-    async def data_to_deconz_session(sensor):
-        """Initialize deCONZ sensor."""
-        deconz_session = await deconz_refresh_state(sensors={"0": sensor})
-        return deconz_session.sensors["0"]
-
-    yield data_to_deconz_session
-
-
-async def test_alarm_sensor(deconz_sensor):
-    """Verify that alarm sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "on": True,
-                "reachable": True,
-                "temperature": 2600,
-            },
-            "ep": 1,
-            "etag": "18c0f3c2100904e31a7f938db2ba9ba9",
-            "manufacturername": "dresden elektronik",
-            "modelid": "lumi.sensor_motion.aq2",
-            "name": "Alarm 10",
-            "state": {
-                "alarm": False,
-                "lastupdated": "none",
-                "lowbattery": None,
-                "tampered": None,
-            },
-            "swversion": "20170627",
-            "type": "ZHAAlarm",
-            "uniqueid": "00:15:8d:00:02:b5:d1:80-01-0500",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHAAlarm",)
-
-    assert sensor.alarm is False
-
-    # DeconzSensor
-    assert sensor.battery == 100
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature == 26
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "18c0f3c2100904e31a7f938db2ba9ba9"
-    assert sensor.manufacturer == "dresden elektronik"
-    assert sensor.model_id == "lumi.sensor_motion.aq2"
-    assert sensor.name == "Alarm 10"
-    assert sensor.software_version == "20170627"
-    assert sensor.type == "ZHAAlarm"
-    assert sensor.unique_id == "00:15:8d:00:02:b5:d1:80-01-0500"
-
-
-async def test_battery_sensor(deconz_sensor):
-    """Verify that alarm sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"alert": "none", "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "23a8659f1cb22df2f51bc2da0e241bb4",
-            "manufacturername": "IKEA of Sweden",
-            "modelid": "FYRTUR block-out roller blind",
-            "name": "FYRTUR block-out roller blind",
-            "state": {"battery": 100, "lastupdated": "none"},
-            "swversion": "2.2.007",
-            "type": "ZHABattery",
-            "uniqueid": "00:0d:6f:ff:fe:01:23:45-01-0001",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHABattery",)
-
-    # DeconzSensor
-    assert sensor.battery == 100
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "23a8659f1cb22df2f51bc2da0e241bb4"
-    assert sensor.manufacturer == "IKEA of Sweden"
-    assert sensor.model_id == "FYRTUR block-out roller blind"
-    assert sensor.name == "FYRTUR block-out roller blind"
-    assert sensor.software_version == "2.2.007"
-    assert sensor.type == "ZHABattery"
-    assert sensor.unique_id == "00:0d:6f:ff:fe:01:23:45-01-0001"
-
-
-async def test_carbonmonoxide_sensor(deconz_sensor):
-    """Verify that carbon monoxide sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "on": True,
-                "pending": [],
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "b7599df551944df97b2aa87d160b9c45",
-            "manufacturername": "Heiman",
-            "modelid": "CO_V16",
-            "name": "Cave, CO",
-            "state": {
-                "carbonmonoxide": False,
-                "lastupdated": "none",
-                "lowbattery": False,
-                "tampered": False,
-            },
-            "swversion": "20150330",
-            "type": "ZHACarbonMonoxide",
-            "uniqueid": "00:15:8d:00:02:a5:21:24-01-0101",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHACarbonMonoxide",)
-
-    assert sensor.carbon_monoxide is False
-
-    # DeconzSensor
-    assert sensor.battery == 100
-    assert sensor.ep == 1
-    assert sensor.low_battery is False
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is False
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "b7599df551944df97b2aa87d160b9c45"
-    assert sensor.manufacturer == "Heiman"
-    assert sensor.model_id == "CO_V16"
-    assert sensor.name == "Cave, CO"
-    assert sensor.software_version == "20150330"
-    assert sensor.type == "ZHACarbonMonoxide"
-    assert sensor.unique_id == "00:15:8d:00:02:a5:21:24-01-0101"
-
-
-async def test_consumption_sensor(deconz_sensor):
-    """Verify that consumption sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "ep": 1,
-            "etag": "a99e5bc463d15c23af7e89946e784cca",
-            "manufacturername": "Heiman",
-            "modelid": "SmartPlug",
-            "name": "Consumption 15",
-            "state": {
-                "consumption": 11342,
-                "lastupdated": "2018-03-12T19:19:08",
-                "power": 123,
-            },
-            "type": "ZHAConsumption",
-            "uniqueid": "00:0d:6f:00:0b:7a:64:29-01-0702",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHAConsumption",)
-
-    assert sensor.consumption == 11342
-    assert sensor.power == 123
-    assert sensor.scaled_consumption == 11.342
-
-    # DeconzSensor
-    assert sensor.battery is None
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "a99e5bc463d15c23af7e89946e784cca"
-    assert sensor.manufacturer == "Heiman"
-    assert sensor.model_id == "SmartPlug"
-    assert sensor.name == "Consumption 15"
-    assert sensor.software_version == ""
-    assert sensor.type == "ZHAConsumption"
-    assert sensor.unique_id == "00:0d:6f:00:0b:7a:64:29-01-0702"
-
-
-async def test_daylight_sensor(deconz_sensor):
-    """Verify that daylight sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "configured": True,
-                "on": True,
-                "sunriseoffset": 30,
-                "sunsetoffset": -30,
-            },
-            "etag": "55047cf652a7e594d0ee7e6fae01dd38",
-            "manufacturername": "Philips",
-            "modelid": "PHDL00",
-            "name": "Daylight",
-            "state": {
-                "daylight": True,
-                "lastupdated": "2018-03-24T17:26:12",
-                "status": 170,
-            },
-            "swversion": "1.0",
-            "type": "Daylight",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("Daylight",)
-
-    assert sensor.configured is True
-    assert sensor.daylight is True
-    assert sensor.status == "solar_noon"
-    assert sensor.sunrise_offset == 30
-    assert sensor.sunset_offset == -30
-
-    # DeconzSensor
-    assert sensor.battery is None
-    assert sensor.ep is None
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "55047cf652a7e594d0ee7e6fae01dd38"
-    assert sensor.manufacturer == "Philips"
-    assert sensor.model_id == "PHDL00"
-    assert sensor.name == "Daylight"
-    assert sensor.software_version == "1.0"
-    assert sensor.type == "Daylight"
-    assert sensor.unique_id == ""
-
-    statuses = {
-        100: "nadir",
-        110: "night_end",
-        120: "nautical_dawn",
-        130: "dawn",
-        140: "sunrise_start",
-        150: "sunrise_end",
-        160: "golden_hour_1",
-        170: "solar_noon",
-        180: "golden_hour_2",
-        190: "sunset_start",
-        200: "sunset_end",
-        210: "dusk",
-        220: "nautical_dusk",
-        230: "night_start",
-        0: "unknown",
-    }
-
-    for k, v in statuses.items():
-        event = {"state": {"status": k}}
-        sensor.update(event)
-
-        assert sensor.changed_keys == {"state", "status"}
-
-
-async def test_fire_sensor(deconz_sensor):
-    """Verify that fire sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "ep": 1,
-            "etag": "2b585d2c016bfd665ba27a8fdad28670",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.sensor_smoke",
-            "name": "sensor_kitchen_smoke",
-            "state": {"fire": False, "lastupdated": "2018-02-20T11:25:02"},
-            "type": "ZHAFire",
-            "uniqueid": "00:15:8d:00:01:d9:3e:7c-01-0500",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHAFire",)
-
-    assert sensor.fire is False
-
-    # DeconzSensor
-    assert sensor.battery is None
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.in_test_mode is False
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "2b585d2c016bfd665ba27a8fdad28670"
-    assert sensor.manufacturer == "LUMI"
-    assert sensor.model_id == "lumi.sensor_smoke"
-    assert sensor.name == "sensor_kitchen_smoke"
-    assert sensor.software_version == ""
-    assert sensor.type == "ZHAFire"
-    assert sensor.unique_id == "00:15:8d:00:01:d9:3e:7c-01-0500"
-
-
-async def test_fire_sensor_test_develco(deconz_sensor):
-    """Verify that develco/frient fire sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "battery": 90, "reachable": True},
-            "ep": 1,
-            "etag": "abcdef1234567890abcdef1234567890",
-            "manufacturername": "frient A/S",
-            "modelid": "SMSZB-120",
-            "name": "Fire alarm",
-            "state": {
-                "fire": False,
-                "lastupdated": "2021-11-25T08:00:02.003",
-                "lowbattery": False,
-                "test": True,
-            },
-            "swversion": "20210526 05:57",
-            "type": "ZHAFire",
-            "uniqueid": "00:11:22:33:44:55:66:77-88-9900",
-        }
-    )
-
-    assert sensor.ZHATYPE == ("ZHAFire",)
-
-    assert sensor.fire is False
-
-    # DeconzSensor
-    assert sensor.battery == 90
-    assert sensor.ep == 1
-    assert sensor.low_battery is False
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.in_test_mode is True
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "abcdef1234567890abcdef1234567890"
-    assert sensor.manufacturer == "frient A/S"
-    assert sensor.model_id == "SMSZB-120"
-    assert sensor.name == "Fire alarm"
-    assert sensor.software_version == "20210526 05:57"
-    assert sensor.type == "ZHAFire"
-    assert sensor.unique_id == "00:11:22:33:44:55:66:77-88-9900"
-
-
-async def test_genericflag_sensor(deconz_sensor):
-    """Verify that generic flag sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "modelid": "Switch",
-            "name": "Kitchen Switch",
-            "state": {"flag": True, "lastupdated": "2018-07-01T10:40:35"},
-            "swversion": "1.0.0",
-            "type": "CLIPGenericFlag",
-            "uniqueid": "kitchen-switch",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("CLIPGenericFlag",)
-
-    assert sensor.flag is True
-
-    # DeconzSensor
-    assert sensor.battery is None
-    assert sensor.ep is None
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == ""
-    assert sensor.manufacturer == ""
-    assert sensor.model_id == "Switch"
-    assert sensor.name == "Kitchen Switch"
-    assert sensor.software_version == "1.0.0"
-    assert sensor.type == "CLIPGenericFlag"
-    assert sensor.unique_id == "kitchen-switch"
-
-
-async def test_genericstatus_sensor(deconz_sensor):
-    """Verify that generic flag sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"on": True, "reachable": True},
-            "etag": "aacc83bc7d6e4af7e44014e9f776b206",
-            "manufacturername": "Phoscon",
-            "modelid": "PHOSCON_FSM_STATE",
-            "name": "FSM_STATE Motion stair",
-            "state": {"lastupdated": "2019-04-24T00:00:25", "status": 0},
-            "swversion": "1.0",
-            "type": "CLIPGenericStatus",
-            "uniqueid": "fsm-state-1520195376277",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("CLIPGenericStatus",)
-
-    assert sensor.status == 0
-
-    # DeconzSensor
-    assert sensor.battery is None
-    assert sensor.ep is None
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "aacc83bc7d6e4af7e44014e9f776b206"
-    assert sensor.manufacturer == "Phoscon"
-    assert sensor.model_id == "PHOSCON_FSM_STATE"
-    assert sensor.name == "FSM_STATE Motion stair"
-    assert sensor.software_version == "1.0"
-    assert sensor.type == "CLIPGenericStatus"
-    assert sensor.unique_id == "fsm-state-1520195376277"
-
-
-async def test_openclose_sensor(deconz_sensor):
-    """Verify that open/close sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 95,
-                "on": True,
-                "reachable": True,
-                "temperature": 3300,
-            },
-            "ep": 1,
-            "etag": "66cc641d0368110da6882b50090174ac",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.sensor_magnet.aq2",
-            "name": "Back Door",
-            "state": {"lastupdated": "2019-05-05T14:54:32", "open": False},
-            "swversion": "20161128",
-            "type": "ZHAOpenClose",
-            "uniqueid": "00:15:8d:00:02:2b:96:b4-01-0006",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHAOpenClose", "CLIPOpenClose")
-
-    assert sensor.open is False
-
-    # DeconzSensor
-    assert sensor.battery == 95
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature == 33
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "66cc641d0368110da6882b50090174ac"
-    assert sensor.manufacturer == "LUMI"
-    assert sensor.model_id == "lumi.sensor_magnet.aq2"
-    assert sensor.name == "Back Door"
-    assert sensor.software_version == "20161128"
-    assert sensor.type == "ZHAOpenClose"
-    assert sensor.unique_id == "00:15:8d:00:02:2b:96:b4-01-0006"
-
-
-@pytest.mark.parametrize(
-    "input,expected",
-    [
-        (
-            {
-                "config": {"on": True, "reachable": True},
-                "ep": 1,
-                "etag": "96e71c7db4685b334d3d0decc3f11868",
-                "manufacturername": "Heiman",
-                "modelid": "SmartPlug",
-                "name": "Power 16",
-                "state": {
-                    "current": 34,
-                    "lastupdated": "2018-03-12T19:22:13",
-                    "power": 64,
-                    "voltage": 231,
-                },
-                "type": "ZHAPower",
-                "uniqueid": "00:0d:6f:00:0b:7a:64:29-01-0b04",
-            },
-            {
-                "ZHATYPE": ("ZHAPower",),
-                "battery": None,
-                "current": 34,
-                "deconz_id": "/sensors/0",
-                "ep": 1,
-                "etag": "96e71c7db4685b334d3d0decc3f11868",
-                "low_battery": None,
-                "manufacturer": "Heiman",
-                "model_id": "SmartPlug",
-                "name": "Power 16",
-                "on": True,
-                "power": 64,
-                "reachable": True,
-                "resource_type": "sensors",
-                "secondary_temperature": None,
-                "software_version": "",
-                "tampered": None,
-                "type": "ZHAPower",
-                "unique_id": "00:0d:6f:00:0b:7a:64:29-01-0b04",
-                "voltage": 231,
-            },
-        ),
-        (
-            {
-                "config": {"on": True, "reachable": True, "temperature": 3400},
-                "ep": 2,
-                "etag": "77ab6ddae6dd81469080ad62118d81b6",
-                "lastseen": "2021-07-07T19:30Z",
-                "manufacturername": "LUMI",
-                "modelid": "lumi.plug.maus01",
-                "name": "Power 27",
-                "state": {"lastupdated": "2021-07-07T19:24:59.664", "power": 1},
-                "swversion": "05-02-2018",
-                "type": "ZHAPower",
-                "uniqueid": "00:15:8d:00:02:82:d3:56-02-000c",
-            },
-            {
-                "ZHATYPE": ("ZHAPower",),
-                "battery": None,
-                "current": None,
-                "deconz_id": "/sensors/0",
-                "ep": 2,
-                "etag": "77ab6ddae6dd81469080ad62118d81b6",
-                "low_battery": None,
-                "manufacturer": "LUMI",
-                "model_id": "lumi.plug.maus01",
-                "name": "Power 27",
-                "on": True,
-                "power": 1,
-                "reachable": True,
-                "secondary_temperature": 34.0,
-                "software_version": "05-02-2018",
-                "tampered": None,
-                "type": "ZHAPower",
-                "unique_id": "00:15:8d:00:02:82:d3:56-02-000c",
-                "voltage": None,
-            },
-        ),
-    ],
-)
-async def test_power_sensor(input, expected, deconz_sensor):
-    """Verify that power sensor works."""
-    sensor = await deconz_sensor(input)
-
-    for attr, value in expected.items():
-        assert getattr(sensor, attr) == value
-
-
-async def test_pressure_sensor(deconz_sensor):
-    """Verify that pressure sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"battery": 100, "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "1220e5d026493b6e86207993703a8a71",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.weather",
-            "name": "Mi temperature 1",
-            "state": {"lastupdated": "2019-05-05T14:39:00", "pressure": 1010},
-            "swversion": "20161129",
-            "type": "ZHAPressure",
-            "uniqueid": "00:15:8d:00:02:45:dc:53-01-0403",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHAPressure", "CLIPPressure")
-
-    assert sensor.pressure == 1010
-
-    # DeconzSensor
-    assert sensor.battery == 100
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "1220e5d026493b6e86207993703a8a71"
-    assert sensor.manufacturer == "LUMI"
-    assert sensor.model_id == "lumi.weather"
-    assert sensor.name == "Mi temperature 1"
-    assert sensor.software_version == "20161129"
-    assert sensor.type == "ZHAPressure"
-    assert sensor.unique_id == "00:15:8d:00:02:45:dc:53-01-0403"
-
-
-async def test_temperature_sensor(deconz_sensor):
-    """Verify that temperature sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"battery": 100, "offset": 0, "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "1220e5d026493b6e86207993703a8a71",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.weather",
-            "name": "Mi temperature 1",
-            "state": {"lastupdated": "2019-05-05T14:39:00", "temperature": 2182},
-            "swversion": "20161129",
-            "type": "ZHATemperature",
-            "uniqueid": "00:15:8d:00:02:45:dc:53-01-0402",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHATemperature", "CLIPTemperature")
-
-    assert sensor.temperature == 2182
-    assert sensor.scaled_temperature == 21.8
-
-    # DeconzSensor
-    assert sensor.battery == 100
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "1220e5d026493b6e86207993703a8a71"
-    assert sensor.manufacturer == "LUMI"
-    assert sensor.model_id == "lumi.weather"
-    assert sensor.name == "Mi temperature 1"
-    assert sensor.software_version == "20161129"
-    assert sensor.type == "ZHATemperature"
-    assert sensor.unique_id == "00:15:8d:00:02:45:dc:53-01-0402"
-
-
-async def test_time_sensor(deconz_sensor):
-    """Verify that time sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {"battery": 40, "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "28e796678d9a24712feef59294343bb6",
-            "lastseen": "2020-11-22T11:26Z",
-            "manufacturername": "Danfoss",
-            "modelid": "eTRV0100",
-            "name": "eTRV Séjour",
-            "state": {
-                "lastset": "2020-11-19T08:07:08Z",
-                "lastupdated": "2020-11-22T10:51:03.444",
-                "localtime": "2020-11-22T10:51:01",
-                "utc": "2020-11-22T10:51:01Z",
-            },
-            "swversion": "20200429",
-            "type": "ZHATime",
-            "uniqueid": "cc:cc:cc:ff:fe:38:4d:b3-01-000a",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHATime",)
-
-    assert sensor.last_set == "2020-11-19T08:07:08Z"
-
-    # DeconzSensor
-    assert sensor.battery == 40
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature is None
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "28e796678d9a24712feef59294343bb6"
-    assert sensor.manufacturer == "Danfoss"
-    assert sensor.model_id == "eTRV0100"
-    assert sensor.name == "eTRV Séjour"
-    assert sensor.software_version == "20200429"
-    assert sensor.type == "ZHATime"
-    assert sensor.unique_id == "cc:cc:cc:ff:fe:38:4d:b3-01-000a"
-
-
-async def test_vibration_sensor(deconz_sensor):
-    """Verify that vibration sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 91,
-                "on": True,
-                "pending": [],
-                "reachable": True,
-                "sensitivity": 21,
-                "sensitivitymax": 21,
-                "temperature": 3200,
-            },
-            "ep": 1,
-            "etag": "b7599df551944df97b2aa87d160b9c45",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.vibration.aq1",
-            "name": "Vibration 1",
-            "state": {
-                "lastupdated": "2019-03-09T15:53:07",
-                "orientation": [10, 1059, 0],
-                "tiltangle": 83,
-                "vibration": True,
-                "vibrationstrength": 114,
-            },
-            "swversion": "20180130",
-            "type": "ZHAVibration",
-            "uniqueid": "00:15:8d:00:02:a5:21:24-01-0101",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHAVibration",)
-
-    assert sensor.orientation == [10, 1059, 0]
-    assert sensor.sensitivity == 21
-    assert sensor.max_sensitivity == 21
-    assert sensor.tilt_angle == 83
-    assert sensor.vibration is True
-    assert sensor.vibration_strength == 114
-
-    # DeconzSensor
-    assert sensor.battery == 91
-    assert sensor.ep == 1
-    assert sensor.low_battery is None
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is None
-    assert sensor.secondary_temperature == 32
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "b7599df551944df97b2aa87d160b9c45"
-    assert sensor.manufacturer == "LUMI"
-    assert sensor.model_id == "lumi.vibration.aq1"
-    assert sensor.name == "Vibration 1"
-    assert sensor.software_version == "20180130"
-    assert sensor.type == "ZHAVibration"
-    assert sensor.unique_id == "00:15:8d:00:02:a5:21:24-01-0101"
-
-    sensor.register_callback(mock_callback := Mock())
-    assert sensor._callbacks
-
-    event = {"state": {"lastupdated": "2019-03-15T10:15:17", "orientation": [0, 84, 6]}}
-    sensor.update(event)
-
-    mock_callback.assert_called_once()
-    assert sensor.changed_keys == {"state", "lastupdated", "orientation"}
-
-    sensor.remove_callback(mock_callback)
-    assert not sensor._callbacks
-
-
-async def test_water_sensor(deconz_sensor):
-    """Verify that water sensor works."""
-    sensor = await deconz_sensor(
-        {
-            "config": {
-                "battery": 100,
-                "on": True,
-                "reachable": True,
-                "temperature": 2500,
-            },
-            "ep": 1,
-            "etag": "fae893708dfe9b358df59107d944fa1c",
-            "manufacturername": "LUMI",
-            "modelid": "lumi.sensor_wleak.aq1",
-            "name": "water2",
-            "state": {
-                "lastupdated": "2019-01-29T07:13:20",
-                "lowbattery": False,
-                "tampered": False,
-                "water": False,
-            },
-            "swversion": "20170721",
-            "type": "ZHAWater",
-            "uniqueid": "00:15:8d:00:02:2f:07:db-01-0500",
-        },
-    )
-
-    assert sensor.ZHATYPE == ("ZHAWater",)
-
-    assert sensor.water is False
-
-    # DeconzSensor
-    assert sensor.battery == 100
-    assert sensor.ep == 1
-    assert sensor.low_battery is False
-    assert sensor.on is True
-    assert sensor.reachable is True
-    assert sensor.tampered is False
-    assert sensor.secondary_temperature == 25
-
-    # DeconzDevice
-    assert sensor.deconz_id == "/sensors/0"
-    assert sensor.etag == "fae893708dfe9b358df59107d944fa1c"
-    assert sensor.manufacturer == "LUMI"
-    assert sensor.model_id == "lumi.sensor_wleak.aq1"
-    assert sensor.name == "water2"
-    assert sensor.software_version == "20170721"
-    assert sensor.type == "ZHAWater"
-    assert sensor.unique_id == "00:15:8d:00:02:2f:07:db-01-0500"
-
 
 async def test_create_all_sensor_types(deconz_refresh_state):
     """Verify that creating all sensors work."""
@@ -861,7 +28,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "20170721",
                 "type": "ZHAWater",
-                "uniqueid": "00:15:8d:00:02:2f:07:db-01-0500",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
             },
             "1": {
                 "config": {
@@ -887,7 +54,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "20180130",
                 "type": "ZHAVibration",
-                "uniqueid": "00:15:8d:00:02:a5:21:24-01-0101",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
             },
             "2": {
                 "config": {"battery": 40, "on": True, "reachable": True},
@@ -905,7 +72,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "20200429",
                 "type": "ZHATime",
-                "uniqueid": "cc:cc:cc:ff:fe:38:4d:b3-01-000a",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-000a",
             },
             "3": {
                 "config": {
@@ -935,7 +102,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "01.02.0008 01.02",
                 "type": "ZHAThermostat",
-                "uniqueid": "14:b4:57:ff:fe:d5:4e:77-01-0201",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0201",
             },
             "4": {
                 "config": {"battery": 100, "offset": 0, "on": True, "reachable": True},
@@ -947,7 +114,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 "state": {"lastupdated": "2019-05-05T14:39:00", "temperature": 2182},
                 "swversion": "20161129",
                 "type": "ZHATemperature",
-                "uniqueid": "00:15:8d:00:02:45:dc:53-01-0402",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0402",
             },
             "5": {
                 "config": {
@@ -971,7 +138,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "20210115",
                 "type": "ZHASwitch",
-                "uniqueid": "00:17:88:01:0b:00:05:5d-01-fc00",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-fc00",
             },
             "6": {
                 "config": {"battery": 100, "on": True, "reachable": True},
@@ -983,7 +150,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 "state": {"lastupdated": "2019-05-05T14:39:00", "pressure": 1010},
                 "swversion": "20161129",
                 "type": "ZHAPressure",
-                "uniqueid": "00:15:8d:00:02:45:dc:53-01-0403",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0403",
             },
             "7": {
                 "config": {
@@ -1006,7 +173,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 "state": {"lastupdated": "2019-05-05T14:37:06", "presence": False},
                 "swversion": "6.1.0.18912",
                 "type": "ZHAPresence",
-                "uniqueid": "00:17:88:01:03:28:8c:9b-02-0406",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-0406",
             },
             "8": {
                 "config": {"on": True, "reachable": True},
@@ -1022,7 +189,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                     "voltage": 231,
                 },
                 "type": "ZHAPower",
-                "uniqueid": "00:0d:6f:00:0b:7a:64:29-01-0b04",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0b04",
             },
             "9": {
                 "config": {
@@ -1039,7 +206,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 "state": {"lastupdated": "2019-05-05T14:54:32", "open": False},
                 "swversion": "20161128",
                 "type": "ZHAOpenClose",
-                "uniqueid": "00:15:8d:00:02:2b:96:b4-01-0006",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0006",
             },
             "10": {
                 "config": {
@@ -1067,7 +234,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "6.1.0.18912",
                 "type": "ZHALightLevel",
-                "uniqueid": "00:17:88:01:03:28:8c:9b-02-0400",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-0400",
             },
             "11": {
                 "config": {"battery": 100, "offset": 0, "on": True, "reachable": True},
@@ -1079,7 +246,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 "state": {"humidity": 3555, "lastupdated": "2019-05-05T14:39:00"},
                 "swversion": "20161129",
                 "type": "ZHAHumidity",
-                "uniqueid": "00:15:8d:00:02:45:dc:53-01-0405",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0405",
             },
             "12": {
                 "config": {"on": True, "reachable": True},
@@ -1116,7 +283,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "20210526 05:57",
                 "type": "ZHAFire",
-                "uniqueid": "00:11:22:33:44:55:66:77-88-9900",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-88-9900",
             },
             "15": {
                 "config": {
@@ -1171,7 +338,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                     "power": 123,
                 },
                 "type": "ZHAConsumption",
-                "uniqueid": "00:0d:6f:00:0b:7a:64:29-01-0702",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0702",
             },
             "18": {
                 "config": {
@@ -1193,7 +360,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "20150330",
                 "type": "ZHACarbonMonoxide",
-                "uniqueid": "00:15:8d:00:02:a5:21:24-01-0101",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0101",
             },
             "19": {
                 "config": {"alert": "none", "on": True, "reachable": True},
@@ -1205,7 +372,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 "state": {"battery": 100, "lastupdated": "none"},
                 "swversion": "2.2.007",
                 "type": "ZHABattery",
-                "uniqueid": "00:0d:6f:ff:fe:01:23:45-01-0001",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0001",
             },
             "20": {
                 "config": {
@@ -1231,7 +398,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "3.13",
                 "type": "ZHAAncillaryControl",
-                "uniqueid": "ec:1b:bd:ff:fe:6f:c3:4d-01-0501",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0501",
             },
             "21": {
                 "config": {
@@ -1253,7 +420,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "20170627",
                 "type": "ZHAAlarm",
-                "uniqueid": "00:15:8d:00:02:b5:d1:80-01-0500",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0500",
             },
             "22": {
                 "config": {"on": True, "reachable": True},
@@ -1270,7 +437,7 @@ async def test_create_all_sensor_types(deconz_refresh_state):
                 },
                 "swversion": "20200402",
                 "type": "ZHAAirQuality",
-                "uniqueid": "00:12:4b:00:14:4d:00:07-02-fdef",
+                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-02-fdef",
             },
         },
     )

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -5,6 +5,8 @@ pytest --cov-report term-missing --cov=pydeconz.sensor tests/test_sensors.py
 
 from tests import sensors as sensor_test_data
 
+from pydeconz.models import ResourceType
+
 
 async def test_create_all_sensors(deconz_refresh_state):
     """Verify that creating all sensors work."""
@@ -39,28 +41,28 @@ async def test_create_all_sensors(deconz_refresh_state):
     )
     sensors = deconz_session.sensors
     assert len(sensors._handlers) == 25
-    assert sensors["0"].type == "ZHAAirPurifier"
-    assert sensors["1"].type == "ZHAAirQuality"
-    assert sensors["2"].type == "ZHAAlarm"
-    assert sensors["3"].type == "ZHAAncillaryControl"
-    assert sensors["4"].type == "ZHABattery"
-    assert sensors["5"].type == "ZHACarbonMonoxide"
-    assert sensors["6"].type == "ZHAConsumption"
-    assert sensors["7"].type == "Daylight"
-    assert sensors["8"].type == "ZHADoorLock"
-    assert sensors["9"].type == "ZHAFire"
-    assert sensors["10"].type == "CLIPGenericFlag"
-    assert sensors["11"].type == "CLIPGenericStatus"
-    assert sensors["12"].type == "ZHAHumidity"
-    assert sensors["13"].type == "ZHALightLevel"
-    assert sensors["14"].type == "ZHAOpenClose"
-    assert sensors["15"].type == "ZHAPower"
-    assert sensors["16"].type == "ZHAPresence"
-    assert sensors["17"].type == "ZHAPressure"
-    assert sensors["18"].type == "ZHARelativeRotary"
-    assert sensors["19"].type == "ZHASwitch"
-    assert sensors["20"].type == "ZHATemperature"
-    assert sensors["21"].type == "ZHAThermostat"
-    assert sensors["22"].type == "ZHATime"
-    assert sensors["23"].type == "ZHAVibration"
-    assert sensors["24"].type == "ZHAWater"
+    assert sensors["0"].type == ResourceType.ZHA_AIR_PURIFIER.value
+    assert sensors["1"].type == ResourceType.ZHA_AIR_QUALITY.value
+    assert sensors["2"].type == ResourceType.ZHA_ALARM.value
+    assert sensors["3"].type == ResourceType.ZHA_ANCILLARY_CONTROL.value
+    assert sensors["4"].type == ResourceType.ZHA_BATTERY.value
+    assert sensors["5"].type == ResourceType.ZHA_CARBON_MONOXIDE.value
+    assert sensors["6"].type == ResourceType.ZHA_CONSUMPTION.value
+    assert sensors["7"].type == ResourceType.DAYLIGHT.value
+    assert sensors["8"].type == ResourceType.ZHA_DOOR_LOCK.value
+    assert sensors["9"].type == ResourceType.ZHA_FIRE.value
+    assert sensors["10"].type == ResourceType.CLIP_GENERIC_FLAG.value
+    assert sensors["11"].type == ResourceType.CLIP_GENERIC_STATUS.value
+    assert sensors["12"].type == ResourceType.ZHA_HUMIDITY.value
+    assert sensors["13"].type == ResourceType.ZHA_LIGHT_LEVEL.value
+    assert sensors["14"].type == ResourceType.ZHA_OPEN_CLOSE.value
+    assert sensors["15"].type == ResourceType.ZHA_POWER.value
+    assert sensors["16"].type == ResourceType.ZHA_PRESENCE.value
+    assert sensors["17"].type == ResourceType.ZHA_PRESSURE.value
+    assert sensors["18"].type == ResourceType.ZHA_RELATIVE_ROTARY.value
+    assert sensors["19"].type == ResourceType.ZHA_SWITCH.value
+    assert sensors["20"].type == ResourceType.ZHA_TEMPERATURE.value
+    assert sensors["21"].type == ResourceType.ZHA_THERMOSTAT.value
+    assert sensors["22"].type == ResourceType.ZHA_TIME.value
+    assert sensors["23"].type == ResourceType.ZHA_VIBRATION.value
+    assert sensors["24"].type == ResourceType.ZHA_WATER.value


### PR DESCRIPTION
Make classes use ResourceType enum values for ZHATYPE
Split out tests to separate files
Split out test data to their own constants
Rename tests so they start with either test_sensor_ or test_handler_