### PR TITLE
Improve light test structure

### DIFF
--- a/tests/lights/test_configuration_tool.py
+++ b/tests/lights/test_configuration_tool.py
@@ -3,24 +3,24 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.lights --cov=pydeconz.models.light.configuration_tool tests/lights/test_configuration_tool.py
 """
 
+DATA = {
+    "etag": "26839cb118f5bf7ba1f2108256644010",
+    "hascolor": False,
+    "lastannounced": None,
+    "lastseen": "2020-11-22T11:27Z",
+    "manufacturername": "dresden elektronik",
+    "modelid": "ConBee II",
+    "name": "Configuration tool 1",
+    "state": {"reachable": True},
+    "swversion": "0x264a0700",
+    "type": "Configuration tool",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01",
+}
 
-async def test_configuration_tool(deconz_light):
+
+async def test_light_configuration_tool(deconz_light):
     """Verify that configuration tool work."""
-    configuration_tool = await deconz_light(
-        {
-            "etag": "26839cb118f5bf7ba1f2108256644010",
-            "hascolor": False,
-            "lastannounced": None,
-            "lastseen": "2020-11-22T11:27Z",
-            "manufacturername": "dresden elektronik",
-            "modelid": "ConBee II",
-            "name": "Configuration tool 1",
-            "state": {"reachable": True},
-            "swversion": "0x264a0700",
-            "type": "Configuration tool",
-            "uniqueid": "00:21:2e:ff:ff:05:a7:a3-01",
-        }
-    )
+    configuration_tool = await deconz_light(DATA)
 
     assert configuration_tool.state is None
     assert configuration_tool.reachable is True
@@ -32,4 +32,4 @@ async def test_configuration_tool(deconz_light):
     assert configuration_tool.name == "Configuration tool 1"
     assert configuration_tool.software_version == "0x264a0700"
     assert configuration_tool.type == "Configuration tool"
-    assert configuration_tool.unique_id == "00:21:2e:ff:ff:05:a7:a3-01"
+    assert configuration_tool.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01"

--- a/tests/lights/test_cover.py
+++ b/tests/lights/test_cover.py
@@ -7,8 +7,46 @@ from unittest.mock import Mock
 
 from pydeconz.interfaces.lights import CoverAction
 
+DATA = {
+    "etag": "87269755b9b3a046485fdae8d96b252c",
+    "hascolor": False,
+    "lastannounced": None,
+    "lastseen": "2020-08-01T16:22:05Z",
+    "manufacturername": "AXIS",
+    "modelid": "Gear",
+    "name": "Covering device",
+    "state": {
+        "bri": 0,
+        "lift": 0,
+        "on": False,
+        "open": True,
+        "reachable": True,
+    },
+    "swversion": "100-5.3.5.1122",
+    "type": "Window covering device",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01",
+}
 
-async def test_control_cover(mock_aioresponse, deconz_session, deconz_called_with):
+DATA_LEGACY = {
+    "etag": "87269755b9b3a046485fdae8d96b252c",
+    "hascolor": False,
+    "lastannounced": None,
+    "lastseen": "2020-08-01T16:22:05Z",
+    "manufacturername": "AXIS",
+    "modelid": "Gear",
+    "name": "Covering device",
+    "state": {
+        "bri": 0,
+        "on": False,
+        "reachable": True,
+    },
+    "swversion": "100-5.3.5.1122",
+    "type": "Window covering device",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01",
+}
+
+
+async def test_handler_cover(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that controlling covers work."""
     covers = deconz_session.lights.covers
 
@@ -35,29 +73,9 @@ async def test_control_cover(mock_aioresponse, deconz_session, deconz_called_wit
     assert deconz_called_with("put", path="/lights/0/state", json={"stop": True})
 
 
-async def test_create_cover(mock_aioresponse, deconz_light, deconz_called_with):
+async def test_light_cover(mock_aioresponse, deconz_light, deconz_called_with):
     """Verify that covers work."""
-    cover = await deconz_light(
-        {
-            "etag": "87269755b9b3a046485fdae8d96b252c",
-            "hascolor": False,
-            "lastannounced": None,
-            "lastseen": "2020-08-01T16:22:05Z",
-            "manufacturername": "AXIS",
-            "modelid": "Gear",
-            "name": "Covering device",
-            "state": {
-                "bri": 0,
-                "lift": 0,
-                "on": False,
-                "open": True,
-                "reachable": True,
-            },
-            "swversion": "100-5.3.5.1122",
-            "type": "Window covering device",
-            "uniqueid": "00:24:46:00:00:12:34:56-01",
-        }
-    )
+    cover = await deconz_light(DATA)
 
     assert cover.state is False
     assert cover.is_open is True
@@ -73,7 +91,7 @@ async def test_create_cover(mock_aioresponse, deconz_light, deconz_called_with):
     assert cover.name == "Covering device"
     assert cover.software_version == "100-5.3.5.1122"
     assert cover.type == "Window covering device"
-    assert cover.unique_id == "00:24:46:00:00:12:34:56-01"
+    assert cover.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01"
 
     cover.register_callback(mock_callback := Mock())
     assert cover._callbacks
@@ -122,25 +140,9 @@ async def test_create_cover(mock_aioresponse, deconz_light, deconz_called_with):
     assert not cover._callbacks
 
 
-async def test_create_cover_without_lift(
-    mock_aioresponse, deconz_light, deconz_called_with
-):
+async def test_light_cover_legacy(mock_aioresponse, deconz_light, deconz_called_with):
     """Verify that covers work with older deconz versions."""
-    cover = await deconz_light(
-        {
-            "etag": "87269755b9b3a046485fdae8d96b252c",
-            "hascolor": False,
-            "lastannounced": None,
-            "lastseen": "2020-08-01T16:22:05Z",
-            "manufacturername": "AXIS",
-            "modelid": "Gear",
-            "name": "Covering device",
-            "state": {"bri": 0, "on": False, "reachable": True},
-            "swversion": "100-5.3.5.1122",
-            "type": "Window covering device",
-            "uniqueid": "00:24:46:00:00:12:34:56-01",
-        }
-    )
+    cover = await deconz_light(DATA_LEGACY)
 
     assert cover.state is False
     assert cover.is_open is True
@@ -156,7 +158,7 @@ async def test_create_cover_without_lift(
     assert cover.name == "Covering device"
     assert cover.software_version == "100-5.3.5.1122"
     assert cover.type == "Window covering device"
-    assert cover.unique_id == "00:24:46:00:00:12:34:56-01"
+    assert cover.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01"
 
     cover.register_callback(mock_callback := Mock())
     assert cover._callbacks

--- a/tests/lights/test_light.py
+++ b/tests/lights/test_light.py
@@ -14,8 +14,36 @@ from pydeconz.models.light import (
 )
 from pydeconz.models.light.light import ColorCapability
 
+DATA = {
+    "colorcapabilities": 15,
+    "ctmax": 500,
+    "ctmin": 153,
+    "etag": "026bcfe544ad76c7534e5ca8ed39047c",
+    "hascolor": True,
+    "manufacturername": "dresden elektronik",
+    "modelid": "FLS-PP3",
+    "name": "Light 1",
+    "pointsymbol": {},
+    "state": {
+        "alert": None,
+        "bri": 111,
+        "colormode": "ct",
+        "ct": 307,
+        "effect": None,
+        "hascolor": True,
+        "hue": 7998,
+        "on": False,
+        "reachable": True,
+        "sat": 172,
+        "xy": [0.421253, 0.39921],
+    },
+    "swversion": "020C.201000A0",
+    "type": "Extended color light",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-0A",
+}
 
-async def test_control_light(mock_aioresponse, deconz_session, deconz_called_with):
+
+async def test_handler_light(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that creating a light works."""
     lights = deconz_session.lights.lights
 
@@ -61,37 +89,9 @@ async def test_control_light(mock_aioresponse, deconz_session, deconz_called_wit
     )
 
 
-async def test_create_light(mock_aioresponse, deconz_light, deconz_called_with):
+async def test_light_light(mock_aioresponse, deconz_light, deconz_called_with):
     """Verify that creating a light works."""
-    light = await deconz_light(
-        {
-            "colorcapabilities": 15,
-            "ctmax": 500,
-            "ctmin": 153,
-            "etag": "026bcfe544ad76c7534e5ca8ed39047c",
-            "hascolor": True,
-            "manufacturername": "dresden elektronik",
-            "modelid": "FLS-PP3",
-            "name": "Light 1",
-            "pointsymbol": {},
-            "state": {
-                "alert": None,
-                "bri": 111,
-                "colormode": "ct",
-                "ct": 307,
-                "effect": None,
-                "hascolor": True,
-                "hue": 7998,
-                "on": False,
-                "reachable": True,
-                "sat": 172,
-                "xy": [0.421253, 0.39921],
-            },
-            "swversion": "020C.201000A0",
-            "type": "Extended color light",
-            "uniqueid": "00:21:2E:FF:FF:00:73:9F-0A",
-        }
-    )
+    light = await deconz_light(DATA)
 
     assert light.state is False
     assert light.on is False
@@ -123,7 +123,7 @@ async def test_create_light(mock_aioresponse, deconz_light, deconz_called_with):
     assert light.name == "Light 1"
     assert light.software_version == "020C.201000A0"
     assert light.type == "Extended color light"
-    assert light.unique_id == "00:21:2E:FF:FF:00:73:9F-0A"
+    assert light.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-0A"
 
     light.register_callback(mock_callback := Mock())
     assert light._callbacks

--- a/tests/lights/test_lock.py
+++ b/tests/lights/test_lock.py
@@ -6,7 +6,26 @@ pytest --cov-report term-missing --cov=pydeconz.interfaces.lights --cov=pydeconz
 from unittest.mock import Mock
 
 
-async def test_control_lock(mock_aioresponse, deconz_session, deconz_called_with):
+DATA = {
+    "etag": "5c2ec06cde4bd654aef3a555fcd8ad12",
+    "hascolor": False,
+    "lastannounced": None,
+    "lastseen": "2020-08-22T15:29:03Z",
+    "manufacturername": "Danalock",
+    "modelid": "V3-BTZB",
+    "name": "Door lock",
+    "state": {
+        "alert": "none",
+        "on": False,
+        "reachable": True,
+    },
+    "swversion": "19042019",
+    "type": "Door Lock",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-00",
+}
+
+
+async def test_handler_lock(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that controlling locks work."""
     locks = deconz_session.lights.locks
 
@@ -19,23 +38,9 @@ async def test_control_lock(mock_aioresponse, deconz_session, deconz_called_with
     assert deconz_called_with("put", path="/lights/0/state", json={"on": False})
 
 
-async def test_create_lock(mock_aioresponse, deconz_light, deconz_called_with):
+async def test_light_lock(deconz_light):
     """Verify that locks work."""
-    lock = await deconz_light(
-        {
-            "etag": "5c2ec06cde4bd654aef3a555fcd8ad12",
-            "hascolor": False,
-            "lastannounced": None,
-            "lastseen": "2020-08-22T15:29:03Z",
-            "manufacturername": "Danalock",
-            "modelid": "V3-BTZB",
-            "name": "Door lock",
-            "state": {"alert": "none", "on": False, "reachable": True},
-            "swversion": "19042019",
-            "type": "Door Lock",
-            "uniqueid": "00:00:00:00:00:00:00:00-00",
-        }
-    )
+    lock = await deconz_light(DATA)
 
     assert lock.state is False
     assert lock.is_locked is False
@@ -49,7 +54,7 @@ async def test_create_lock(mock_aioresponse, deconz_light, deconz_called_with):
     assert lock.name == "Door lock"
     assert lock.software_version == "19042019"
     assert lock.type == "Door Lock"
-    assert lock.unique_id == "00:00:00:00:00:00:00:00-00"
+    assert lock.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-00"
 
     lock.register_callback(mock_callback := Mock())
     assert lock._callbacks

--- a/tests/lights/test_range_extender.py
+++ b/tests/lights/test_range_extender.py
@@ -3,22 +3,25 @@
 pytest --cov-report term-missing --cov=pydeconz.interfaces.lights --cov=pydeconz.models.light.range_extender tests/lights/test_range_extender.py
 """
 
+DATA = {
+    "etag": "62a220a6141a5956a6916633cad0d56f",
+    "hascolor": False,
+    "manufacturername": "IKEA of Sweden",
+    "modelid": "TRADFRI signal repeater",
+    "name": "Range extender 64",
+    "state": {
+        "alert": "none",
+        "reachable": True,
+    },
+    "swversion": "2.0.019",
+    "type": "Range extender",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01",
+}
 
-async def test_range_extender(deconz_light):
+
+async def test_light_range_extender(deconz_light):
     """Verify that range extender work."""
-    range_extender = await deconz_light(
-        {
-            "etag": "62a220a6141a5956a6916633cad0d56f",
-            "hascolor": False,
-            "manufacturername": "IKEA of Sweden",
-            "modelid": "TRADFRI signal repeater",
-            "name": "Range extender 64",
-            "state": {"alert": "none", "reachable": True},
-            "swversion": "2.0.019",
-            "type": "Range extender",
-            "uniqueid": "00:0d:6f:ff:fe:9f:7f:52-01",
-        }
-    )
+    range_extender = await deconz_light(DATA)
 
     assert range_extender.state is None
     assert range_extender.reachable is True
@@ -30,4 +33,4 @@ async def test_range_extender(deconz_light):
     assert range_extender.name == "Range extender 64"
     assert range_extender.software_version == "2.0.019"
     assert range_extender.type == "Range extender"
-    assert range_extender.unique_id == "00:0d:6f:ff:fe:9f:7f:52-01"
+    assert range_extender.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01"

--- a/tests/lights/test_siren.py
+++ b/tests/lights/test_siren.py
@@ -7,8 +7,23 @@ from unittest.mock import Mock
 
 from pydeconz.models.light import ALERT_KEY, ALERT_LONG, ALERT_NONE, ON_TIME_KEY
 
+DATA = {
+    "etag": "0667cb8fff2adc1bf22be0e6eece2a18",
+    "hascolor": False,
+    "manufacturername": "Heiman",
+    "modelid": "WarningDevice",
+    "name": "alarm_tuin",
+    "state": {
+        "alert": "none",
+        "reachable": True,
+    },
+    "swversion": None,
+    "type": "Warning device",
+    "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01",
+}
 
-async def test_control_siren(mock_aioresponse, deconz_session, deconz_called_with):
+
+async def test_handler_siren(mock_aioresponse, deconz_session, deconz_called_with):
     """Verify that sirens work."""
     sirens = deconz_session.lights.sirens
 
@@ -37,21 +52,9 @@ async def test_control_siren(mock_aioresponse, deconz_session, deconz_called_wit
     )
 
 
-async def test_create_siren(deconz_light):
+async def test_light_siren(deconz_light):
     """Verify that sirens work."""
-    siren = await deconz_light(
-        {
-            "etag": "0667cb8fff2adc1bf22be0e6eece2a18",
-            "hascolor": False,
-            "manufacturername": "Heiman",
-            "modelid": "WarningDevice",
-            "name": "alarm_tuin",
-            "state": {"alert": "none", "reachable": True},
-            "swversion": None,
-            "type": "Warning device",
-            "uniqueid": "00:0d:6f:00:0f:ab:12:34-01",
-        }
-    )
+    siren = await deconz_light(DATA)
 
     assert siren.state is None
     assert siren.is_on is False
@@ -65,7 +68,7 @@ async def test_create_siren(deconz_light):
     assert siren.name == "alarm_tuin"
     assert not siren.software_version
     assert siren.type == "Warning device"
-    assert siren.unique_id == "00:0d:6f:00:0f:ab:12:34-01"
+    assert siren.unique_id == "xx:xx:xx:xx:xx:xx:xx:xx-01"
 
     siren.register_callback(mock_callback := Mock())
     assert siren._callbacks

--- a/tests/test_lights.py
+++ b/tests/test_lights.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from tests import lights as light_test_data
+
 from pydeconz.interfaces.lights import FanSpeed
 from pydeconz.models.light.fan import FAN_SPEED_100_PERCENT
 
@@ -125,30 +127,8 @@ async def test_create_all_light_types(deconz_refresh_state):
     """Verify that light types work."""
     deconz_session = await deconz_refresh_state(
         lights={
-            "0": {
-                "etag": "0667cb8fff2adc1bf22be0e6eece2a18",
-                "hascolor": False,
-                "manufacturername": "Heiman",
-                "modelid": "WarningDevice",
-                "name": "alarm_tuin",
-                "state": {"alert": "none", "reachable": True},
-                "swversion": None,
-                "type": "Warning device",
-                "uniqueid": "00:0d:6f:00:0f:ab:12:34-01",
-            },
-            "1": {
-                "etag": "5c2ec06cde4bd654aef3a555fcd8ad12",
-                "hascolor": False,
-                "lastannounced": None,
-                "lastseen": "2020-08-22T15:29:03Z",
-                "manufacturername": "Danalock",
-                "modelid": "V3-BTZB",
-                "name": "Door lock",
-                "state": {"alert": "none", "on": False, "reachable": True},
-                "swversion": "19042019",
-                "type": "Door Lock",
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            },
+            "0": light_test_data.test_configuration_tool.DATA,
+            "1": light_test_data.test_cover.DATA,
             "2": {
                 "etag": "432f3de28965052961a99e3c5494daf4",
                 "hascolor": False,
@@ -166,68 +146,19 @@ async def test_create_all_light_types(deconz_refresh_state):
                 "type": "Fan",
                 "uniqueid": "00:22:a3:00:00:27:8b:81-01",
             },
-            "3": {
-                "etag": "87269755b9b3a046485fdae8d96b252c",
-                "hascolor": False,
-                "lastannounced": None,
-                "lastseen": "2020-08-01T16:22:05Z",
-                "manufacturername": "AXIS",
-                "modelid": "Gear",
-                "name": "Covering device",
-                "state": {"bri": 0, "on": False, "reachable": True},
-                "swversion": "100-5.3.5.1122",
-                "type": "Window covering device",
-                "uniqueid": "00:24:46:00:00:12:34:56-01",
-            },
-            "4": {
-                "etag": "26839cb118f5bf7ba1f2108256644010",
-                "hascolor": False,
-                "lastannounced": None,
-                "lastseen": "2020-11-22T11:27Z",
-                "manufacturername": "dresden elektronik",
-                "modelid": "ConBee II",
-                "name": "Configuration tool 1",
-                "state": {"reachable": True},
-                "swversion": "0x264a0700",
-                "type": "Configuration tool",
-                "uniqueid": "00:21:2e:ff:ff:05:a7:a3-01",
-            },
-            "5": {
-                "ctmax": 500,
-                "ctmin": 153,
-                "etag": "026bcfe544ad76c7534e5ca8ed39047c",
-                "hascolor": True,
-                "manufacturername": "dresden elektronik",
-                "modelid": "FLS-PP3",
-                "name": "Light 1",
-                "pointsymbol": {},
-                "state": {
-                    "alert": None,
-                    "bri": 111,
-                    "colormode": "ct",
-                    "ct": 307,
-                    "effect": None,
-                    "hascolor": True,
-                    "hue": 7998,
-                    "on": False,
-                    "reachable": True,
-                    "sat": 172,
-                    "xy": [0.421253, 0.39921],
-                },
-                "swversion": "020C.201000A0",
-                "type": "Extended color light",
-                "uniqueid": "00:21:2E:FF:FF:00:73:9F-0A",
-            },
+            "3": light_test_data.test_light.DATA,
+            "4": light_test_data.test_lock.DATA,
+            "5": light_test_data.test_siren.DATA,
             "6": {"type": "unsupported device"},
         },
     )
 
     lights = deconz_session.lights
     assert len(lights.keys()) == 7
-    assert lights["0"].type == "Warning device"
-    assert lights["1"].type == "Door Lock"
+    assert lights["0"].type == "Configuration tool"
+    assert lights["1"].type == "Window covering device"
     assert lights["2"].type == "Fan"
-    assert lights["3"].type == "Window covering device"
-    assert lights["4"].type == "Configuration tool"
-    assert lights["5"].type == "Extended color light"
+    assert lights["3"].type == "Extended color light"
+    assert lights["4"].type == "Door Lock"
+    assert lights["5"].type == "Warning device"
     assert lights["6"].type == "unsupported device"  # legacy support


### PR DESCRIPTION
Split out test data to their own constants
Rename tests so they start with either test_light_ or test_handler_