### PR TITLE
Make GroupedAPIItems process_item more resilient to unsupported resource types

### DIFF
--- a/pydeconz/interfaces/api.py
+++ b/pydeconz/interfaces/api.py
@@ -155,15 +155,15 @@ class GroupedAPIItems(Generic[DataResource]):
     resource_group: ResourceGroup
 
     def __init__(
-        self, gateway: DeconzSession, api_items: list[APIItems[DataResource]]
+        self, gateway: DeconzSession, handlers: list[APIItems[DataResource]]
     ) -> None:
         """Initialize sensor manager."""
         self.gateway = gateway
-        self._handlers = api_items
+        self._handlers = handlers
 
-        self._type_to_handler: dict[ResourceType, APIItems[DataResource]] = {
+        self._resource_type_to_handler: dict[ResourceType, APIItems[DataResource]] = {
             resource_type: handler
-            for handler in api_items
+            for handler in handlers
             if handler.resource_types is not None
             for resource_type in handler.resource_types
         }
@@ -198,7 +198,11 @@ class GroupedAPIItems(Generic[DataResource]):
                 handler.process_item(id, raw)
                 return
 
-        handler = self._type_to_handler[ResourceType(raw.get("type"))]
+        if (
+            resource_type := ResourceType(raw.get("type"))
+        ) not in self._resource_type_to_handler:
+            return
+        handler = self._resource_type_to_handler[resource_type]
         handler.process_item(id, raw)
 
     def subscribe(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,6 +124,21 @@ async def test_api_items(mock_aioresponse, deconz_refresh_state):
     unsub_apiitems_4()
 
 
+async def test_unsupported_resource_type(deconz_refresh_state):
+    """Verify that creation of APIItems works as expected."""
+    session = await deconz_refresh_state(
+        alarm_systems={"1": {"type": "unknown_type"}},
+        groups={"1": {"type": "unknown_type", "scenes": []}},
+        lights={"1": {"type": "unknown_type"}},
+        sensors={"1": {"type": "unknown_type"}},
+    )
+
+    assert len(session.alarmsystems.keys()) == 1
+    assert len(session.groups.keys()) == 1
+    assert len(session.lights.keys()) == 1  # Legacy support
+    assert len(session.sensors.keys()) == 0
+
+
 @patch("pydeconz.gateway.sleep", new_callable=AsyncMock)
 async def test_retry_on_bridge_busy(_, deconz_refresh_state):
     """Verify a max count of 4 bridge busy messages."""


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/74523

Support for starkvind has been handled, but there might be new resource types that shouldn't break normal operations