### PR TITLE
Don't set group effect to None when updating color state from a light

### DIFF
--- a/pydeconz/models/group.py
+++ b/pydeconz/models/group.py
@@ -208,6 +208,11 @@ class Group(DeconzDevice):
                 continue
 
             if update_all_attributes:
-                data[attribute] = None if attribute != "xy" else (None, None)
+                if attribute == "xy":
+                    data[attribute] = (None, None)
+                elif attribute == "effect":
+                    data[attribute] = LightEffect.NONE.value
+                else:
+                    data[attribute] = None
 
         self.update({"action": data})

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -238,7 +238,7 @@ async def test_enum_group_properties(deconz_refresh_state, path, property, data)
                 "sat": 1,
                 "xy": (0.1, 0.1),
                 "colormode": LightColorMode.XY,
-                "effect": LightEffect.UNKNOWN,
+                "effect": LightEffect.NONE,
             },
         ),
         (
@@ -255,7 +255,7 @@ async def test_enum_group_properties(deconz_refresh_state, path, property, data)
                 "sat": None,
                 "xy": None,
                 "colormode": LightColorMode.CT,
-                "effect": LightEffect.UNKNOWN,
+                "effect": LightEffect.NONE,
             },
         ),
     ],


### PR DESCRIPTION
Reported on HASS forums `2022-07-29 15:39:00.113 WARNING (MainThread) [pydeconz.models.light.light] Unexpected light effect type None`