### PR TITLE
Make sure deconz_device properties always return a string

### DIFF
--- a/pydeconz/models/deconz_device.py
+++ b/pydeconz/models/deconz_device.py
@@ -14,40 +14,40 @@ class DeconzDevice(APIItem):
     def etag(self) -> str:
         """HTTP etag change on any action to the device."""
         raw: dict[str, str] = self.raw
-        return raw.get("etag", "")
+        return raw.get("etag") or ""
 
     @property
     def manufacturer(self) -> str:
         """Device manufacturer."""
         raw: dict[str, str] = self.raw
-        return raw.get("manufacturername", "")
+        return raw.get("manufacturername") or ""
 
     @property
     def model_id(self) -> str:
         """Device model."""
         raw: dict[str, str] = self.raw
-        return raw.get("modelid", "")
+        return raw.get("modelid") or ""
 
     @property
     def name(self) -> str:
         """Name of the device."""
         raw: dict[str, str] = self.raw
-        return raw.get("name", "")
+        return raw.get("name") or ""
 
     @property
     def software_version(self) -> str:
         """Firmware version."""
         raw: dict[str, str] = self.raw
-        return raw.get("swversion", "")
+        return raw.get("swversion") or ""
 
     @property
     def type(self) -> str:
         """Human readable type of the device."""
         raw: dict[str, str] = self.raw
-        return raw.get("type", "")
+        return raw.get("type") or ""
 
     @property
     def unique_id(self) -> str:
         """Id for unique device identification."""
         raw: dict[str, str] = self.raw
-        return raw.get("uniqueid", "")
+        return raw.get("uniqueid") or ""


### PR DESCRIPTION
Daylight unique ID can in some instances be None, reported here https://github.com/home-assistant/core/issues/84587