### PR TITLE
Add support for Tuya Smart Air Housekeeper 6in1 Air Quality Monitor

### DIFF
--- a/pydeconz/models/sensor/air_quality.py
+++ b/pydeconz/models/sensor/air_quality.py
@@ -87,3 +87,8 @@ class AirQuality(SensorBase):
     def supports_pm_2_5(self) -> bool:
         """Support Air quality PM2.5 reporting."""
         return "pm2_5" in self.raw["state"]
+
+    @property
+    def supports_air_quality(self) -> bool:
+        """Support Air quality reporting."""
+        return "airquality" in self.raw["state"]

--- a/pydeconz/models/sensor/air_quality.py
+++ b/pydeconz/models/sensor/air_quality.py
@@ -22,6 +22,8 @@ class TypedAirQualityState(TypedDict):
     ]
     airqualityppb: int
     pm2_5: int
+    airqualityformaldehyd: int
+    airqualityco2: int
 
 
 class TypedAirQuality(TypedDict):
@@ -77,6 +79,16 @@ class AirQuality(SensorBase):
     def pm_2_5(self) -> int | None:
         """Air quality PM2.5 (µg/m³)."""
         return self.raw["state"].get("pm2_5")
+
+    @property
+    def air_quality_formaldehyd(self) -> int | None:
+        """Chemical compound gas formaldehyde / methanal (CH2O) (µg/m³)."""
+        return self.raw["state"].get("airqualityformaldehyd")
+
+    @property
+    def air_quality_co2(self) -> int | None:
+        """Chemical compound gas carbon dioxid (CO2) (ppb)."""
+        return self.raw["state"].get("airqualityco2")
 
     @property
     def supports_air_quality_ppb(self) -> bool:

--- a/pydeconz/models/sensor/air_quality.py
+++ b/pydeconz/models/sensor/air_quality.py
@@ -66,7 +66,7 @@ class AirQuality(SensorBase):
     @property
     def air_quality(self) -> str:  # AirQualityValue:
         """Air quality."""
-        return AirQualityValue(self.raw["state"]["airquality"]).value
+        return AirQualityValue(self.raw["state"].get("airquality")).value
 
     @property
     def air_quality_ppb(self) -> int | None:


### PR DESCRIPTION

Goal: Add support for [Tuya Smart Air Housekeeper](https://zigbee.blakadder.com/Tuya_DCR-KQG.html) (aka TS0601 | _TZE200_dwcarsat)

This PR is a part of series of PR's affecting deconz-rest-plugin, pydeconz, homeassistant.
List: 

The commit [61a1fdd](https://github.com/Kane610/deconz/commit/61a1fdd51e3e9c29d9855caca8e1db758f4ed628) is required to prevent pydeconz from crashing if the airquality value is none - the sensor doesn't support it.
In HA this will be used in combination with commit [f9bc6d](https://github.com/Kane610/deconz/commit/f9bca6db80fb5e19871bbea1f210cfd70a556188) "supports airquality" check to hide the empty airquality sensor entity.

Result in HA once all PR's are merged:
