### PR TITLE
Fix enum.Flag issue occuring with Python3.11.1

### DIFF
--- a/pydeconz/models/alarm_system.py
+++ b/pydeconz/models/alarm_system.py
@@ -43,7 +43,7 @@ class AlarmSystemArmState(enum.Enum):
     IN_ALARM = "in_alarm"
 
 
-class AlarmSystemArmMask(enum.Flag):
+class AlarmSystemArmMask(enum.Enum):
     """The target arm mode."""
 
     ARMED_AWAY = "A"


### PR DESCRIPTION
❯ pytest --cov-report term-missing --cov=pydeconz tests/ ImportError while loading conftest '/Users/robban/Development/deconz/tests/conftest.py'.
tests/conftest.py:10: in <module>
    from pydeconz import DeconzSession
pydeconz/__init__.py:2: in <module>
    from .gateway import DeconzSession  # noqa: F401
pydeconz/gateway.py:12: in <module>
    from .interfaces.alarm_systems import AlarmSystems
pydeconz/interfaces/alarm_systems.py:6: in <module>
    from ..models.alarm_system import (
pydeconz/models/alarm_system.py:46: in <module>
    class AlarmSystemArmMask(enum.Flag):
/opt/homebrew/Cellar/python@3.11/3.11.2/Frameworks/Python.framework/Versions/3.11/lib/python3.11/enum.py:560: in __new__
    raise exc
/opt/homebrew/Cellar/python@3.11/3.11.2/Frameworks/Python.framework/Versions/3.11/lib/python3.11/enum.py:300: in __set_name__
    and _is_single_bit(value)
/opt/homebrew/Cellar/python@3.11/3.11.2/Frameworks/Python.framework/Versions/3.11/lib/python3.11/enum.py:98: in _is_single_bit
    num &= num - 1
E   TypeError: unsupported operand type(s) for -: 'str' and 'int'