### PR TITLE
Remove hardcoded temperature and humidity rounding

### DIFF
--- a/pydeconz/models/sensor/humidity.py
+++ b/pydeconz/models/sensor/humidity.py
@@ -37,7 +37,7 @@ class Humidity(SensorBase):
     @property
     def scaled_humidity(self) -> float:
         """Scaled humidity level."""
-        return round(self.humidity / 100, 1)
+        return self.humidity / 100
 
     @property
     def offset(self) -> int | None:

--- a/pydeconz/models/sensor/temperature.py
+++ b/pydeconz/models/sensor/temperature.py
@@ -30,4 +30,4 @@ class Temperature(SensorBase):
     @property
     def scaled_temperature(self) -> float:
         """Scaled temperature."""
-        return round(self.temperature / 100, 1)
+        return self.temperature / 100

--- a/tests/sensors/test_humidity.py
+++ b/tests/sensors/test_humidity.py
@@ -40,7 +40,7 @@ async def test_sensor_humidity(deconz_sensor):
 
     assert sensor.humidity == 3555
     assert sensor.offset == 0
-    assert sensor.scaled_humidity == 35.5
+    assert sensor.scaled_humidity == 35.55
 
     # DeconzSensor
     assert sensor.battery == 100

--- a/tests/sensors/test_temperature.py
+++ b/tests/sensors/test_temperature.py
@@ -30,7 +30,7 @@ async def test_sensor_temperature(deconz_sensor):
     sensor = await deconz_sensor(DATA)
 
     assert sensor.temperature == 2182
-    assert sensor.scaled_temperature == 21.8
+    assert sensor.scaled_temperature == 21.82
 
     # DeconzSensor
     assert sensor.battery == 100


### PR DESCRIPTION
Now when [we can set sensor precision](https://www.home-assistant.io/blog/2023/03/01/release-20233/#sensor-display-precision) directly in Home Assistant UI, could we please remove hardcoded rounding to 1 decimal place from pydeconz?

Also solves #127 