### PR TITLE
Add more effects for Philips Hue lights

### DIFF
--- a/pydeconz/models/light/light.py
+++ b/pydeconz/models/light/light.py
@@ -25,6 +25,18 @@ class TypedLightStateGradient(TypedDict):
     ]
 
 
+class TypedLightCapabilitiesColor(TypedDict):
+    """Light capabilities color type definition."""
+
+    effects: NotRequired[list[str]]
+
+
+class TypedLightCapabilities(TypedDict):
+    """Light capabilities type definition."""
+
+    color: NotRequired[TypedLightCapabilitiesColor]
+
+
 class TypedLightState(TypedDict):
     """Light state type definition."""
 
@@ -94,6 +106,7 @@ class TypedLightState(TypedDict):
 class TypedLight(TypedDict):
     """Light type definition."""
 
+    capabilities: NotRequired[TypedLightCapabilities]
     colorcapabilities: NotRequired[int]
     ctmax: int
     ctmin: int
@@ -308,6 +321,17 @@ class Light(LightBase):
         but minimum brightness.
         """
         return self.raw["state"].get("bri")
+
+    @property
+    def supported_effects(self) -> list[LightEffect] | None:
+        """List of effects supported by a light."""
+        if (
+            "capabilities" in self.raw
+            and "color" in self.raw["capabilities"]
+            and "effects" in self.raw["capabilities"]["color"]
+        ):
+            return list(map(LightEffect, self.raw["capabilities"]["color"]["effects"]))
+        return None
 
     @property
     def color_capabilities(self) -> LightColorCapability | None:

--- a/pydeconz/models/light/light.py
+++ b/pydeconz/models/light/light.py
@@ -62,9 +62,12 @@ class TypedLightState(TypedDict):
             "fireplace",
             "fireworks",
             "flag",
+            "glisten",
             "glow",
             "loop",
             "none",
+            "opal",
+            "prism",
             "rainbow",
             "snake",
             "snow",
@@ -73,6 +76,7 @@ class TypedLightState(TypedDict):
             "steady",
             "strobe",
             "sunrise",
+            "sunset",
             "twinkle",
             "updown",
             "vintage",
@@ -192,8 +196,11 @@ class LightEffect(enum.StrEnum):
     - "fireplace"
     - "fireworks"
     - "flag"
+    - "glisten"
     - "glow"
     - "loop"
+    - "opal"
+    - "prism"
     - "rainbow"
     - "snake"
     - "snow"
@@ -202,6 +209,7 @@ class LightEffect(enum.StrEnum):
     - "steady"
     - "strobe"
     - "sunrise"
+    - "sunset"
     - "twinkle"
     - "updown"
     - "vintage"
@@ -215,9 +223,16 @@ class LightEffect(enum.StrEnum):
 
     CANDLE = "candle"
     FIREPLACE = "fireplace"
+    # 'loop' has been renamed 'prism' in deCONZ since Sept. 2023.
+    # https://github.com/dresden-elektronik/deconz-rest-plugin/pull/7206/commits/9be934389e62583bc7f17b1bb2c7dff718f5f938
+    # Keeping it to remain compatible with older versions of deCONZ.
     LOOP = "loop"
+    GLISTEN = "glisten"
+    OPAL = "opal"
+    PRISM = "prism"
     SPARKLE = "sparkle"
     SUNRISE = "sunrise"
+    SUNSET = "sunset"
 
     # Specific to Lidl christmas light (TS0601)
 

--- a/tests/lights/test_light.py
+++ b/tests/lights/test_light.py
@@ -13,6 +13,42 @@ from pydeconz.models.light.light import (
 )
 
 DATA = {
+    "capabilities": {
+        "alerts": [
+            "none",
+            "select",
+            "lselect",
+            "blink",
+            "breathe",
+            "okay",
+            "channelchange",
+            "finish",
+            "stop",
+        ],
+        "bri": {"min_dim_level": 0.2},
+        "color": {
+            "ct": {"computes_xy": True, "max": 500, "min": 153},
+            "effects": [
+                "none",
+                "colorloop",
+                "candle",
+                "fireplace",
+                "prism",
+                "sunrise",
+                "sunset",
+                "sparkle",
+                "opal",
+                "glisten",
+            ],
+            "gamut_type": "C",
+            "modes": ["ct", "effect", "hs", "xy"],
+            "xy": {
+                "blue": [0.1532, 0.0475],
+                "green": [0.17, 0.7],
+                "red": [0.6915, 0.3083],
+            },
+        },
+    },
     "colorcapabilities": 15,
     "ctmax": 500,
     "ctmin": 153,
@@ -140,6 +176,19 @@ async def test_handler_fan(mock_aioresponse, deconz_session, deconz_called_with)
 async def test_light_light(mock_aioresponse, deconz_light, deconz_called_with):
     """Verify that creating a light works."""
     light = await deconz_light(DATA)
+
+    assert light.supported_effects == [
+        LightEffect.NONE,
+        LightEffect.COLOR_LOOP,
+        LightEffect.CANDLE,
+        LightEffect.FIREPLACE,
+        LightEffect.PRISM,
+        LightEffect.SUNRISE,
+        LightEffect.SUNSET,
+        LightEffect.SPARKLE,
+        LightEffect.OPAL,
+        LightEffect.GLISTEN,
+    ]
 
     assert light.state is False
     assert light.on is False
@@ -298,9 +347,26 @@ async def test_enum_light_properties_no_key(deconz_light):
     """Verify enum properties return expected values or None."""
     light = await deconz_light({"config": {}, "state": {}, "type": "Color light"})
 
+    assert light.supported_effects is None
     assert light.alert is None
     assert light.color_capabilities is None
     assert light.color_mode is None
     assert light.effect is None
     with pytest.raises(KeyError):
         assert light.fan_speed
+
+
+ENUM_CAPABILITIES_DATA = [
+    ({"capabilities": {}}),
+    ({"capabilities": {"color": {}}}),
+]
+
+
+@pytest.mark.parametrize(("data"), ENUM_CAPABILITIES_DATA)
+async def test_enum_light_properties_no_capabilities(deconz_light, data):
+    """Verify enum properties return expected values or None."""
+    light = await deconz_light(
+        {"config": {}, "state": {}, "type": "Color light"} | data
+    )
+
+    assert light.supported_effects is None


### PR DESCRIPTION
Recent firmware updates for Philips Hue lights have added additional lighting effects. This PR updates the library's list to include them.

Additionally, this PR fetches the effects a light reports as supported from the `capabilities` key that was [recently added](https://github.com/dresden-elektronik/deconz-rest-plugin/pull/6316) to deCONZ's REST API. This enables a follow up PR to the Home Assistant integration that would add these effects to the light entities.